### PR TITLE
feat: implement `Union_find` and `Var` in `mlsus.std`

### DIFF
--- a/lib/std/dune
+++ b/lib/std/dune
@@ -1,0 +1,5 @@
+(library
+ (name mlsus_std)
+ (public_name mlsus.std)
+ (libraries core)
+ (preprocess (pps ppx_jane)))

--- a/lib/std/mlsus_std.ml
+++ b/lib/std/mlsus_std.ml
@@ -1,0 +1,8 @@
+module Var = Var
+module Union_find = Union_find
+
+let post_incr r =
+  let result = !r in
+  incr r;
+  result
+;;

--- a/lib/std/union_find.ml
+++ b/lib/std/union_find.ml
@@ -1,0 +1,141 @@
+open Base
+
+(* This module implements an imperative data structure for disjoint sets
+   (commonly known as `union-find'), based on Tarjan and Huet.
+
+   Union find implements a family of disjoint sets on values, where
+   the disjoint sets can dynamically be combined using [union].
+
+   A disjoint set [D] is a family of disjoint sets [D = {t1, ..., tn}],
+   with the following operations:
+   - [create v]: creates a new set [t] containing [v] in [D].
+   - [find v] returns the (unique) set [t] in [D] that contains [v].
+   - [union t1 t2] performs the union of [t1] and [t2] in [D].
+
+   A disjoint set [D] is represeted using a forest, a collection of trees,
+   each node in the tree storing it's value, with pointers to parents.
+
+   Operations:
+   - [find v]:
+     This traverses the element [v] back to the root [r] of the set,
+     creating a path [p] (the `find' path).
+
+   Path compression is performed on this operation, which updates the
+   parent pointer to point directly to the root [r].
+
+   - [union t1 t2]:
+     We use union by rank. Each set stores the `rank', an upper bound for the
+     height of the tree. The set with the smallest rank becomes the child,
+     with the edge case of equal ranks.
+
+   This implementation is optimized for the representation of equivalent
+   classes. Each equivalence class containing a "value".
+*)
+
+(* Trees representing equivalence classes are of the form:
+   {v
+            Root
+             |
+           Inner
+        / .. | .. \
+     Inner Inner Inner
+      /|\   /|\   /|\
+      ...   ...   ...
+   v}
+
+   With directed edges towards the parents.
+   The root of the class contains the [rank] and value of type ['a].
+   Internal nodes contain a pointer to their parent.
+*)
+
+type 'a root =
+  { rank : int
+  ; value : 'a
+  }
+
+and 'a node =
+  | Root of 'a root
+  | Inner of 'a t
+
+and 'a t = 'a node ref [@@deriving sexp_of]
+
+let invariant _ t =
+  let rec loop t height =
+    match !t with
+    | Root r -> assert (height <= r.rank)
+    | Inner t -> loop t (height + 1)
+  in
+  loop t 0
+;;
+
+let create v = ref (Root { rank = 0; value = v })
+
+(* [compress t ~imm_desc ~imm_desc_node ~prop_descs] compresses the path
+   from [t] upwards to the root of [t]'s tree, where:
+   - [imm_desc] is the immediate descendent of [t], and
+   - [prop_descs] are proper descendents of [imm_desc]
+
+   The use of [imm_desc_node] is to avoid additional heap allocation
+   when performing path compression.
+*)
+let rec compress t ~imm_desc ~imm_desc_node ~prop_descs =
+  match !t with
+  | Root r ->
+    (* Perform path compression *)
+    List.iter prop_descs ~f:(fun t -> t := imm_desc_node);
+    (* Return pointer to root and it's contents *)
+    t, r
+  | Inner t' as imm_desc_node ->
+    compress t' ~imm_desc:t ~imm_desc_node ~prop_descs:(imm_desc :: prop_descs)
+;;
+
+let repr t =
+  match !t with
+  | Root r -> t, r
+  | Inner t' as imm_desc_node -> compress t' ~imm_desc:t ~imm_desc_node ~prop_descs:[]
+;;
+
+let root t =
+  match !t with
+  | Root _ -> t
+  | _ -> fst (repr t)
+;;
+
+let rec get t =
+  match !t with
+  | Root { value; _ } -> value
+  | Inner t' ->
+    (match !t' with
+     | Root { value; _ } -> value
+     | Inner _ -> get (root t))
+;;
+
+let rec set t v =
+  match !t with
+  | Root { rank; _ } -> t := Root { rank; value = v }
+  | Inner t' ->
+    (match !t' with
+     | Root { rank; _ } -> t := Root { rank; value = v }
+     | Inner _ -> set (root t) v)
+;;
+
+let union t1 t2 =
+  let t1, { rank = r1; value = _ } = repr t1 in
+  let t2, { rank = r2; value = v2 } = repr t2 in
+  if phys_equal t1 t2
+  then ()
+  else if r2 < r1
+  then t2 := Inner t1
+  else (
+    let r = if r1 < r2 then r1 else r1 + 1 in
+    t1 := Inner t2;
+    t2 := Root { rank = r; value = v2 })
+;;
+
+let same_class t1 t2 = phys_equal (root t1) (root t2)
+
+let is_root t =
+  match !t with
+  | Root _ -> true
+  | Inner _ -> false
+;;

--- a/lib/std/union_find.mli
+++ b/lib/std/union_find.mli
@@ -1,0 +1,40 @@
+open Base
+
+(** This module implements an imperative data structure for disjoint sets
+    (commonly known as `union-find'), based on Tarjan and Huet.
+
+    Union find implements a family of disjoint sets on values, where
+    the disjoint sets can dynamically be combined using [union].
+
+    This implementation is optimized for the representation of equivalent
+    classes. Each equivalence class containing a "value".
+
+    This implementation is not (yet) thread-safe. *)
+
+(** The type ['a t] denotes a node in an equivalence class associated with a
+    unique value of type ['a]. *)
+type 'a t [@@deriving sexp_of]
+
+include Invariant.S1 with type 'a t := 'a t
+
+(** [create v] creates a new node representing a singleton class with value [v]. *)
+val create : 'a -> 'a t
+
+(** [get t] returns the value of the equivalence class of [t]. *)
+val get : 'a t -> 'a
+
+(** [set t v] sets the value of the equivalence class of [t] to [v]. *)
+val set : 'a t -> 'a -> unit
+
+(** [union t1 t2] merges the equivalence classes of [t1] and [t2].
+    The value of the combined class is the value of [t1] or [t2]; it is unspecified which.
+
+    After [union t1 t2], [t1 === t2] always holds true. *)
+val union : 'a t -> 'a t -> unit
+
+(** [same_class t1 t2] returns true iff [t1] and [t2] belong to the same
+    equivalence class. *)
+val same_class : 'a t -> 'a t -> bool
+
+(** [is_root t] returns true if [t] is the root of an equivalence class *)
+val is_root : 'a t -> bool

--- a/lib/std/var.ml
+++ b/lib/std/var.ml
@@ -1,0 +1,37 @@
+open Core
+
+module Make (X : sig
+    val module_name : string
+  end) : sig
+  type t = private
+    { id : int
+    ; name : string
+    }
+
+  val create : ?name:string -> unit -> t
+
+  include Identifiable.S with type t := t
+end = struct
+  module T = struct
+    type t =
+      { id : int
+      ; name : string
+      }
+    [@@deriving equal, compare, hash, bin_io, sexp]
+
+    let create =
+      let next_id = ref 0 in
+      fun ?(name = X.module_name) () ->
+        next_id := !next_id + 1;
+        { id = !next_id; name }
+    ;;
+
+    let of_string s = s |> Sexp.of_string |> t_of_sexp
+    let to_string t = t |> sexp_of_t |> Sexp.to_string
+
+    include X
+  end
+
+  include T
+  include Identifiable.Make (T)
+end


### PR DESCRIPTION
# Context

A simple standard library extension that provides the union find data structure (required for unification), `Var` (a helpful variable functor) and `post_incr`