### PR TITLE
fix: `Union_find.union` descriptor updates

### DIFF
--- a/lib/std/dune
+++ b/lib/std/dune
@@ -2,4 +2,5 @@
  (name mlsus_std)
  (public_name mlsus.std)
  (libraries core)
- (preprocess (pps ppx_jane)))
+ (preprocess
+  (pps ppx_jane)))

--- a/lib/unifier/unifier.ml
+++ b/lib/unifier/unifier.ml
@@ -80,7 +80,7 @@ module Make (S : Structure.Basic) = struct
         ~ctx
         ~create:Type.create
         ~unify:(Work_queue.enqueue work_queue)
-        ~type1 
+        ~type1
         ~type2
         (Type.structure type1)
         (Type.structure type2)


### PR DESCRIPTION
# Context

Discovered cases where `unify type1 type2` did not imply `Type.structure type1 = Type.structure type2`. This is due to a bug in `Union_find.union`