### PR TITLE
fix(solver): instantiation now correctly copies variables

### DIFF
--- a/lib/constraint/constraint.ml
+++ b/lib/constraint/constraint.ml
@@ -66,7 +66,14 @@ and scheme =
 let tt = True
 let ff err = False err
 let ( &~ ) t1 t2 = Conj (t1, t2)
-let all ts = List.fold ts ~init:tt ~f:( &~ )
+
+let all ts =
+  match ts with
+  | [] -> tt
+  | [ t ] -> t
+  | ts -> List.fold ts ~init:tt ~f:( &~ )
+;;
+
 let ( =~ ) type1 type2 = Eq (type1, type2)
 let exists type_var t = Exists (type_var, t)
 let exists_many vars in_ = List.fold_right vars ~init:in_ ~f:exists

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -168,7 +168,6 @@ module S = struct
 
   exception Cannot_merge = Inner.Cannot_merge
 
-  let map t ~f = { t with inner = Inner.map t.inner ~f }
   let iter t ~f = Inner.iter t.inner ~f
   let fold t ~init ~f = Inner.fold t.inner ~init ~f
 
@@ -605,7 +604,7 @@ let partial_copy ~state ~curr_region type_ =
            | _ -> false
          in
          if should_copy_structure
-         then Type.set_inner copy (S.Inner.map structure.inner ~f:loop);
+         then Type.set_inner copy (S.Inner.copy structure.inner ~f:loop);
          copy)
   in
   loop ~root:true type_
@@ -928,7 +927,7 @@ let instantiate ~state ~curr_region ({ root; region_node } : Type.t Scheme.t) =
        | Not_found_s _ ->
          let copy = partial_instantiate ~state ~curr_region type_ in
          Hashtbl.set copies ~key:structure.id ~data:copy;
-         Type.set_inner copy (S.Inner.map structure.inner ~f:loop);
+         Type.set_inner copy (S.Inner.copy ~f:loop structure.inner);
          copy)
   in
   loop root

--- a/lib/constraint_solver/structure.ml
+++ b/lib/constraint_solver/structure.ml
@@ -29,6 +29,8 @@ module Former = struct
     | Constr (ts, constr) -> Constr (List.map ts ~f, constr)
   ;;
 
+  let copy t ~f = map t ~f
+
   let fold t ~f ~init =
     match t with
     | Arrow (t1, t2) -> f t2 (f t1 init)
@@ -110,16 +112,10 @@ module Suspended_first_order (S : S) = struct
     | Structure s -> S.fold s ~f ~init
   ;;
 
-  let map t ~f =
+  let copy t ~f =
     match t with
-    | Var var ->
-      (* FIXME(): [map] doesn't have the signature ['a t -> f:('a -> 'b) -> 'b t]
-
-         Because the ['a] in [Var] is in a negative position, making it
-         costly to map over. Additionally all of our uses of [map] in
-         [Generalization] are homomorphic. *)
-      Var var
-    | Structure s -> Structure (S.map s ~f)
+    | Var _ -> Var Empty
+    | Structure s -> Structure (S.copy s ~f)
   ;;
 
   let merge ~ctx ~create ~unify ~type1 ~type2 t1 t2 =

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -874,3 +874,28 @@ let%expect_test "" =
   type_check_and_print str;
   [%expect {| Well typed :) |}]
 ;;
+
+let%expect_test "" =
+  let str =
+    {|
+      type m = 
+        | L 
+      ;;
+
+      type n = 
+        | L 
+      ;; 
+
+      let bad = 
+        let f = fun x -> match x with (L -> 1) in 
+        f (L : m)
+      ;; 
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    (num_partially_generalized_regions(num_partially_generalized_regions 2))
+    ("Failed to solve constraint" (err Cannot_resume_match_due_to_cycle))
+    |}]
+;;

--- a/lib/unifier/structure.ml
+++ b/lib/unifier/structure.ml
@@ -8,8 +8,8 @@ end
 module type Traverse = sig
   include Basic
 
-  (** [map t ~f] traverses [t], applying the transformation [f]. *)
-  val map : 'a t -> f:('a -> 'b) -> 'b t
+  (** [copy t ~f] copies [t] using [f] to copy each child. *)
+  val copy : 'a t -> f:('a -> 'a) -> 'a t
 
   (** [iter t ~f] traverses [t], executing [f] on each child. *)
   val iter : 'a t -> f:('a -> unit) -> unit


### PR DESCRIPTION
Previously if a variable contained handlers, then these handlers would be copied to the instances. This is not the correct semantics. 


This PR fixes this, removing `map` (which caused this issue), replacing it with `copy` (which has better semantics)