### PR TITLE
feat(type_checker): add support for annotations with polymorphic types

### DIFF
--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -42,6 +42,7 @@ and expression_desc =
   | Exp_app of expression * expression
   | Exp_let of value_binding * expression
   | Exp_exists of Type_var_name.With_range.t list * expression
+  | Exp_forall of Type_var_name.With_range.t list * expression
   | Exp_annot of expression * core_type
   | Exp_constr of Constructor_name.With_range.t * expression option
   | Exp_tuple of expression list

--- a/lib/ast/ast_builder.ml
+++ b/lib/ast/ast_builder.ml
@@ -49,6 +49,9 @@ module type S = sig
     val exists
       : (Type_var_name.With_range.t list -> expression -> expression) with_range_fn
 
+    val forall
+      : (Type_var_name.With_range.t list -> expression -> expression) with_range_fn
+
     val annot : (expression -> core_type -> expression) with_range_fn
 
     val constr
@@ -138,6 +141,10 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
       With_range.create ~range @@ Exp_exists (type_var_names, exp)
     ;;
 
+    let forall ~range type_var_names exp =
+      With_range.create ~range @@ Exp_forall (type_var_names, exp)
+    ;;
+
     let annot ~range exp type_ = With_range.create ~range @@ Exp_annot (exp, type_)
 
     let constr ~range constr_name arg_exp =
@@ -214,6 +221,7 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
     let fun_ = Expression.fun_ ~range:R.v
     let app = Expression.app ~range:R.v
     let let_ = Expression.let_ ~range:R.v
+    let forall = Expression.forall ~range:R.v
     let exists = Expression.exists ~range:R.v
     let annot = Expression.annot ~range:R.v
     let constr = Expression.constr ~range:R.v

--- a/lib/constraint/constraint.ml
+++ b/lib/constraint/constraint.ml
@@ -21,6 +21,7 @@ module Type = struct
       | Arrow of Var.t * Var.t
       | Tuple of Var.t list
       | Constr of Var.t list * Ident.t
+      | Rigid_var
     [@@deriving sexp]
   end
 
@@ -64,10 +65,14 @@ type t =
   | With_range of t * Range.t
 
 and scheme =
-  { type_vars : Type.Var.t list
+  { type_vars : (flexibility * Type.Var.t) list
   ; in_ : t
   ; type_ : Type.t
   }
+
+and flexibility =
+  | Flexible
+  | Rigid
 [@@deriving sexp]
 
 let tt = True

--- a/lib/constraint/constraint.mli
+++ b/lib/constraint/constraint.mli
@@ -13,6 +13,7 @@ module Type : sig
       | Arrow of Var.t * Var.t
       | Tuple of Var.t list
       | Constr of Var.t list * Ident.t
+      | Rigid_var
     [@@deriving sexp]
   end
 
@@ -55,10 +56,14 @@ type t =
 
 (** [scheme] is a constrainted type scheme [overline(a). C => tau] *)
 and scheme =
-  { type_vars : Type.Var.t list
+  { type_vars : (flexibility * Type.Var.t) list
   ; in_ : t
   ; type_ : Type.t
   }
+
+and flexibility =
+  | Flexible
+  | Rigid
 [@@deriving sexp]
 
 val tt : t
@@ -71,10 +76,10 @@ val exists_many : Type.Var.t list -> t -> t
 val ( #= ) : Var.t -> scheme -> Var.t * scheme
 
 type unquantified_scheme := t * Type.t
-type quantified_scheme := Type.Var.t list * unquantified_scheme
+type quantified_scheme := (flexibility * Type.Var.t) list * unquantified_scheme
 
 val ( @=> ) : t -> Type.t -> unquantified_scheme
-val ( @. ) : Type.Var.t list -> unquantified_scheme -> quantified_scheme
+val ( @. ) : (flexibility * Type.Var.t) list -> unquantified_scheme -> quantified_scheme
 val mono_scheme : Type.t -> scheme
 val poly_scheme : quantified_scheme -> scheme
 val let_ : Var.t * scheme -> in_:t -> t

--- a/lib/constraint_solver/decoded_type.ml
+++ b/lib/constraint_solver/decoded_type.ml
@@ -116,6 +116,10 @@ module Decoder = struct
       and decode_first_order_structure ~id structure =
         match structure with
         | Var _ -> Var (State.rename_var state id)
+        | Structure s -> decode_rigid_structure ~id s
+      and decode_rigid_structure ~id structure =
+        match structure with
+        | Rigid_var -> Var (State.rename_var state id)
         | Structure former -> decode_former former
       and decode_former former =
         match former with

--- a/lib/constraint_solver/dune
+++ b/lib/constraint_solver/dune
@@ -1,6 +1,13 @@
 (library
  (name mlsus_constraint_solver)
  (public_name mlsus.constraint_solver)
- (libraries core async grace mlsus.std mlsus.unifier mlsus.constraint mlsus.error)
+ (libraries
+  core
+  async
+  grace
+  mlsus.std
+  mlsus.unifier
+  mlsus.constraint
+  mlsus.error)
  (preprocess
   (pps ppx_jane)))

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -243,7 +243,7 @@ let%expect_test "No suspended matches results in normal generalization" =
     exists a1
     @@ let_
          xid#=(poly_scheme
-                 ([ a2 ]
+                 ([ Flexible, a2 ]
                   @. (exists a3
                       @@ exists a4
                       @@ (T.(var a2 =~ var a3 @-> var a4)
@@ -264,7 +264,7 @@ let%expect_test "No suspended matches results in normal generalization" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let ((id 6) (name Constraint.Var))
-        ((type_vars (((id 1) (name Type.Var))))
+        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
          (in_
           (Exists ((id 2) (name Type.Var))
            (Exists ((id 3) (name Type.Var))
@@ -302,7 +302,7 @@ let%expect_test "Partial generic becomes instance" =
     @@ exists a2
     @@ let_
          x1#=(poly_scheme
-                ([ a3 ]
+                ([ Flexible, a3 ]
                  @. match_
                       a1
                       ~closure:[ a3; a2 ]
@@ -319,7 +319,7 @@ let%expect_test "Partial generic becomes instance" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let ((id 3) (name Constraint.Var))
-         ((type_vars (((id 2) (name Type.Var))))
+         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
           (in_
            (Match (matchee ((id 0) (name Type.Var)))
             (closure
@@ -344,7 +344,7 @@ let%expect_test "Partial generic becomes generic" =
     exists a1
     @@ let_
          x1#=(poly_scheme
-                ([ a2 ]
+                ([ Flexible, a2 ]
                  @. match_
                       a1
                       ~closure:[ a2 ]
@@ -363,7 +363,7 @@ let%expect_test "Partial generic becomes generic" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let ((id 3) (name Constraint.Var))
-        ((type_vars (((id 1) (name Type.Var))))
+        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
          (in_
           (Match (matchee ((id 0) (name Type.Var)))
            (closure ((type_vars (((id 1) (name Type.Var)))))) (case <fun>)
@@ -393,7 +393,7 @@ let%expect_test "Propagating changes during partial generalization" =
     exists_many [ a1; a2 ]
     @@ let_
          x1#=(poly_scheme
-                ([ a3 ]
+                ([ Flexible, a3 ]
                  @. ((* This match forces [a3] to be partially generic *)
                      match_ a1 ~closure:[ a3 ] ~with_:(fun _ -> tt) ~else_:else_unsat_err
                      &~
@@ -424,7 +424,7 @@ let%expect_test "Propagating changes during partial generalization" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let ((id 4) (name Constraint.Var))
-         ((type_vars (((id 2) (name Type.Var))))
+         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
           (in_
            (Conj
             (Match (matchee ((id 0) (name Type.Var)))

--- a/lib/error/mlsus_error.ml
+++ b/lib/error/mlsus_error.ml
@@ -17,6 +17,7 @@ module Code = struct
     | Constructor_arity_mismatch
     | Ambiguous_constructor
     | Type_mismatch
+    | Rigid_variable_escape
     | Unknown
   [@@deriving sexp]
 
@@ -32,6 +33,7 @@ module Code = struct
     | Constructor_arity_mismatch -> "E009"
     | Ambiguous_constructor -> "E010"
     | Type_mismatch -> "E011"
+    | Rigid_variable_escape -> "E012"
     | Unknown -> "E???"
   ;;
 end
@@ -247,6 +249,7 @@ let constructor_disambiguation_mismatched_type ~range ~type_head =
     match type_head with
     | `Tuple -> "tuple"
     | `Arrow -> "function type"
+    | `Rigid_var -> "polymorphic variable"
   in
   Diagnostic.createf
     ~labels:[ Label.primaryf ~range "expected a type constructor, found a %s" head_name ]
@@ -263,6 +266,14 @@ let ambiguous_constructor ~range =
     ~code:Code.Ambiguous_constructor
     Error
     "ambiguous constructor"
+;;
+
+let rigid_variable_escape ~range =
+  Diagnostic.createf
+    ~labels:[ empty_primary_label ~range ]
+    ~code:Code.Rigid_variable_escape
+    Error
+    "generic type variable escapes its scope"
 ;;
 
 module For_testing = struct

--- a/lib/error/mlsus_error.mli
+++ b/lib/error/mlsus_error.mli
@@ -58,8 +58,10 @@ val ambiguous_constructor : range:Range.t -> t
 
 val constructor_disambiguation_mismatched_type
   :  range:Range.t
-  -> type_head:[ `Tuple | `Arrow ]
+  -> type_head:[ `Tuple | `Arrow | `Rigid_var ]
   -> t
+
+val rigid_variable_escape : range:Range.t -> t
 
 module For_testing : sig
   val use_expect_test_config : unit -> unit

--- a/lib/main/test/dune
+++ b/lib/main/test/dune
@@ -1,6 +1,6 @@
 (library
  (name test_main)
- (libraries core grace async fmt mlsus.main)
+ (libraries core grace async dedent fmt mlsus.main)
  (inline_tests)
  (preprocess
   (pps ppx_jane -log-source-position)))

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -936,7 +936,7 @@ let%expect_test "" =
     Generated constraint:
     (With_range
      (Let ((id 4) (name id))
-      ((type_vars (((id 0) (name Type.Var))))
+      ((type_vars ((Flexible ((id 0) (name Type.Var)))))
        (in_
         (With_range
          (Exists ((id 1) (name Type.Var))

--- a/lib/parser/lexer.mll
+++ b/lib/parser/lexer.mll
@@ -17,6 +17,7 @@ let keywords =
   ; "match", MATCH 
   ; "with", WITH 
   ; "exists", EXISTS 
+  ; "forall", FORALL
   ; "type", TYPE 
   ; "as", AS 
   ; "of", OF 

--- a/lib/parser/mlsus_parser.ml
+++ b/lib/parser/mlsus_parser.ml
@@ -37,6 +37,7 @@ module Token = struct
     | FUN -> Fmt.pf ppf "Fun"
     | EXTERNAL -> Fmt.pf ppf "External"
     | EXISTS -> Fmt.pf ppf "Exists"
+    | FORALL -> Fmt.pf ppf "Forall"
     | EQUAL -> Fmt.pf ppf "Equal"
     | EOF -> Fmt.pf ppf "Eof"
     | ELSE -> Fmt.pf ppf "Else"

--- a/lib/parser/parser.mly
+++ b/lib/parser/parser.mly
@@ -247,6 +247,14 @@ expression:
     ; "->"
     ; exp = seq_expression
       { Expression.exists ~range:(range_of_lex $loc) type_var_names exp }
+  | "forall"
+    ; "("
+    ; "type"
+    ; type_var_names = nonempty_list(type_var_name)
+    ; ")"
+    ; "->"
+    ; exp = seq_expression
+        { Expression.forall ~range:(range_of_lex $loc) type_var_names exp }
   | "match" 
     ; exp = expression 
     ; "with" 

--- a/lib/parser/test/test_parser.ml
+++ b/lib/parser/test/test_parser.ml
@@ -1179,6 +1179,109 @@ let%expect_test "annotation : exists" =
     |}]
 ;;
 
+let%expect_test "annotation : forall" =
+  let exp =
+    {| forall (type 'a) -> 
+        fun (x : 'a) -> (x : 'a)
+    |}
+  in
+  parse_and_print_expression exp;
+  [%expect
+    {|
+    ((it
+      (Exp_forall
+       (((it a)
+         (range
+          ((start 14) (stop 16)
+           (source
+            (Reader
+             ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>))))))))
+       ((it
+         (Exp_fun
+          (((it
+             (Pat_annot
+              ((it
+                (Pat_var
+                 ((it x)
+                  (range
+                   ((start 35) (stop 36)
+                    (source
+                     (Reader
+                      ((id 0) (name (expect_test.ml)) (length 59)
+                       (unsafe_get <fun>)))))))))
+               (range
+                ((start 35) (stop 36)
+                 (source
+                  (Reader
+                   ((id 0) (name (expect_test.ml)) (length 59)
+                    (unsafe_get <fun>)))))))
+              ((it
+                (Type_var
+                 ((it a)
+                  (range
+                   ((start 39) (stop 41)
+                    (source
+                     (Reader
+                      ((id 0) (name (expect_test.ml)) (length 59)
+                       (unsafe_get <fun>)))))))))
+               (range
+                ((start 39) (stop 41)
+                 (source
+                  (Reader
+                   ((id 0) (name (expect_test.ml)) (length 59)
+                    (unsafe_get <fun>)))))))))
+            (range
+             ((start 34) (stop 42)
+              (source
+               (Reader
+                ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>))))))))
+          ((it
+            (Exp_annot
+             ((it
+               (Exp_var
+                ((it x)
+                 (range
+                  ((start 47) (stop 48)
+                   (source
+                    (Reader
+                     ((id 0) (name (expect_test.ml)) (length 59)
+                      (unsafe_get <fun>)))))))))
+              (range
+               ((start 47) (stop 48)
+                (source
+                 (Reader
+                  ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>)))))))
+             ((it
+               (Type_var
+                ((it a)
+                 (range
+                  ((start 51) (stop 53)
+                   (source
+                    (Reader
+                     ((id 0) (name (expect_test.ml)) (length 59)
+                      (unsafe_get <fun>)))))))))
+              (range
+               ((start 51) (stop 53)
+                (source
+                 (Reader
+                  ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>)))))))))
+           (range
+            ((start 46) (stop 54)
+             (source
+              (Reader
+               ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>)))))))))
+        (range
+         ((start 30) (stop 54)
+          (source
+           (Reader
+            ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>)))))))))
+     (range
+      ((start 1) (stop 54)
+       (source
+        (Reader ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>)))))))
+    |}]
+;;
+
 let%expect_test "let : fact" =
   let exp =
     {| let fact = fix (fun fact n -> 

--- a/lib/parser/token.mly
+++ b/lib/parser/token.mly
@@ -12,6 +12,7 @@
 %token MATCH "match"
 %token WITH "with"
 %token EXISTS "exists"
+%token FORALL "forall"
 %token TYPE "type"
 %token AS "as"
 %token OF "of"

--- a/lib/type_checker/dune
+++ b/lib/type_checker/dune
@@ -1,6 +1,13 @@
 (library
  (name mlsus_type_checker)
  (public_name mlsus.type_checker)
- (libraries core grace mlsus.std mlsus.ast mlsus.constraint mlsus.constraint_solver mlsus.error)
+ (libraries
+  core
+  grace
+  mlsus.std
+  mlsus.ast
+  mlsus.constraint
+  mlsus.constraint_solver
+  mlsus.error)
  (preprocess
   (pps ppx_jane)))

--- a/lib/type_checker/mlsus_type_checker.ml
+++ b/lib/type_checker/mlsus_type_checker.ml
@@ -64,6 +64,8 @@ let check cst =
               ~pp_type:Mlsus_constraint_solver.Decoded_type.pp
               type1
               type2)
+     | Rigid_variable_escape ->
+       Mlsus_error.(raise @@ rigid_variable_escape ~range:(get_range range))
      | Cannot_resume_suspended_generic errs | Cannot_resume_match_due_to_cycle errs ->
        (* FIXME: We don't have a way to compose many errors into one, so we just pick one for now :/ *)
        Mlsus_error.raise @@ List.hd_exn errs)


### PR DESCRIPTION
This PR adds support for the `forall (type 'a1 ... 'an) -> e` construct in MLsus. This permits one to annotate an expression with a _polymorphic type variable_.