### PR TITLE
fix(solver): copy partial generic structures if they don't have associated instances

### DIFF
--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -824,7 +824,7 @@ let create_former ~state ~curr_region ?guards former =
   create_type ~state ~curr_region ?guards (Structure (Structure former))
 ;;
 
-let partial_copy ~state ~curr_region type_ =
+let partial_copy ~state ~curr_region ~instance_id type_ =
   (* Copy generics fully, partial generics are shallowly copied (only fresh vars) *)
   let copies = Hashtbl.create (module Identifier) in
   let rec loop ?(root = false) type_ =
@@ -842,6 +842,17 @@ let partial_copy ~state ~curr_region type_ =
            ||
            match structure.status with
            | Generic -> true
+           | Partial ({ kind = Generic; instances; region_node = _ } as ps)
+             when not (Map.mem instances instance_id) ->
+             Type.add_guard copy ~guard:(Instance instance_id) ~data:();
+             Type.set_structure
+               type_
+               { structure with
+                 status =
+                   Partial
+                     { ps with instances = Map.set instances ~key:instance_id ~data:copy }
+               };
+             true
            | _ -> false
          in
          if should_copy_structure
@@ -1087,7 +1098,7 @@ let generalize_young_region ~state (young_region : Young_region.t) =
         visit_region ~state curr_region;
         (* Perform a partial copy on the generic to ensure the instance has the generalized
            structure and then unify *)
-        let copy = partial_copy ~state ~curr_region partial_generic in
+        let copy = partial_copy ~state ~curr_region ~instance_id partial_generic in
         (* NOTE: Scheduler jobs that are queued by [unify] and [remove_guard] only visit siblings or parents. *)
         unify ~state ~curr_region copy instance));
   (* Generalize partial generics that can be generalized to (full) generics *)


### PR DESCRIPTION
Another bug fix from #45.

When copying structures from a partial generic to an instance, we currently stop copying the structures once we reach a partial generic. The idea being that we'd visit this partial generic later/earlier and copy it's structures. But this isn't complete. 

There is another case where we'd reach a partial generic but never had/will visit it -- the partial generic was produced by generalising a partial instance that is reachable from a partial generic that has instances. In this case, the instance map of the generic in question is empty.

This PR fixes `partial_copy` to check the instance map -- if it doesn't contain the instance id, then we guard the copied type, add the instance to the instance map, and mark that it's structure should be copied. 

The logic of `partial_copy` and instantiate is very similar now (we should investigate whether we can merge the two functions)