### PR TITLE
feat(unifier): add support for rolling back unification updates on error

### DIFF
--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -535,7 +535,7 @@ let%expect_test "Partial ungeneralization (Partial<>Instance)" =
           (Eq (Var ((id 0) (name Type.Var))) (Constr () ((id 0) (name int)))))))))
      (err
       ((it
-        (Cannot_unify (Constr () ((id 1) (name string)))
+        (Cannot_unify (Var ((id 0) (name Decoded_type.Var)))
          (Constr () ((id 1) (name string)))))
        (range ()))))
     |}]
@@ -596,8 +596,8 @@ let%expect_test "Partial ungeneralization (Partial<>Partial)" =
          (Eq (Var ((id 0) (name Type.Var))) (Constr () ((id 1) (name string))))))))
      (err
       ((it
-        (Cannot_unify (Constr () ((id 1) (name string)))
-         (Constr () ((id 1) (name string)))))
+        (Cannot_unify (Var ((id 0) (name Decoded_type.Var)))
+         (Var ((id 1) (name Decoded_type.Var)))))
        (range ()))))
     |}]
 ;;
@@ -661,7 +661,7 @@ let%expect_test "Partials propagate to same instance group" =
      (err
       ((it
         (Cannot_unify (Var ((id 0) (name Decoded_type.Var)))
-         (Var ((id 0) (name Decoded_type.Var)))))
+         (Var ((id 1) (name Decoded_type.Var)))))
        (range ()))))
     |}]
 ;;

--- a/lib/std/union_find.ml
+++ b/lib/std/union_find.ml
@@ -32,6 +32,62 @@ open Base
    classes. Each equivalence class containing a "value".
 *)
 
+module Transactional_store = struct
+  module Ref = struct
+    type 'a t =
+      { mutable contents : 'a (** The current (uncommitted) value *)
+      ; mutable committed_contents : 'a (** The last committed value *)
+      }
+    [@@deriving sexp]
+
+    type packed = Packed : 'a t -> packed [@@deriving sexp_of]
+
+    let create contents = { contents; committed_contents = contents }
+    let equal = phys_equal
+  end
+
+  type t = { mutable transaction : transaction option }
+  and transaction = Ref.packed Stack.t [@@deriving sexp_of]
+
+  let t = { transaction = None }
+  let get (ref : _ Ref.t) = ref.contents
+
+  let set (ref : 'a Ref.t) (value : 'a) =
+    if phys_equal ref.contents value
+    then ()
+    else (
+      match t.transaction with
+      | None ->
+        ref.contents <- value;
+        ref.committed_contents <- value
+      | Some tx ->
+        if phys_equal ref.contents ref.committed_contents then Stack.push tx (Packed ref);
+        ref.contents <- value)
+  ;;
+
+  let commit_ref (Ref.Packed ref) = ref.committed_contents <- ref.contents
+  let rollback_ref (Ref.Packed ref) = ref.contents <- ref.committed_contents
+
+  let try_or_rollback ~f =
+    match t.transaction with
+    | Some _ -> raise_s [%message "Cannot nest transactions"]
+    | None ->
+      let tx = Stack.create () in
+      t.transaction <- Some tx;
+      (try
+         let result = f () in
+         Stack.iter tx ~f:commit_ref;
+         t.transaction <- None;
+         result
+       with
+       | exn ->
+         let bt = Backtrace.get () in
+         Stack.iter tx ~f:rollback_ref;
+         t.transaction <- None;
+         Exn.raise_with_original_backtrace exn bt)
+  ;;
+end
+
 (* Trees representing equivalence classes are of the form:
    {v
             Root
@@ -49,26 +105,26 @@ open Base
 *)
 
 type 'a root =
-  { mutable rank : int
-  ; mutable value : 'a
+  { rank : int
+  ; value : 'a
   }
 
 and 'a node =
   | Root of 'a root
   | Inner of 'a t
 
-and 'a t = 'a node ref [@@deriving sexp_of]
+and 'a t = 'a node Transactional_store.Ref.t [@@deriving sexp_of]
 
 let invariant _ t =
   let rec loop t height =
-    match !t with
+    match Transactional_store.get t with
     | Root r -> assert (height <= r.rank)
     | Inner t -> loop t (height + 1)
   in
   loop t 0
 ;;
 
-let create v = ref (Root { rank = 0; value = v })
+let create v = Transactional_store.Ref.create (Root { rank = 0; value = v })
 
 (* [compress t ~imm_desc ~imm_desc_node ~prop_descs] compresses the path
    from [t] upwards to the root of [t]'s tree, where:
@@ -79,10 +135,10 @@ let create v = ref (Root { rank = 0; value = v })
    when performing path compression.
 *)
 let rec compress t ~imm_desc ~imm_desc_node ~prop_descs =
-  match !t with
+  match Transactional_store.get t with
   | Root r ->
     (* Perform path compression *)
-    List.iter prop_descs ~f:(fun t -> t := imm_desc_node);
+    List.iter prop_descs ~f:(fun t -> Transactional_store.set t imm_desc_node);
     (* Return pointer to root and it's contents *)
     t, r
   | Inner t' as imm_desc_node ->
@@ -90,39 +146,47 @@ let rec compress t ~imm_desc ~imm_desc_node ~prop_descs =
 ;;
 
 let repr t =
-  match !t with
+  match Transactional_store.get t with
   | Root r -> t, r
   | Inner t' as imm_desc_node -> compress t' ~imm_desc:t ~imm_desc_node ~prop_descs:[]
 ;;
 
 let root t =
-  match !t with
+  match Transactional_store.get t with
   | Root r -> r
   | _ -> snd (repr t)
 ;;
 
 let get t = (root t).value
-let set t v = (root t).value <- v
+
+let set t v =
+  let t, root = repr t in
+  Transactional_store.set t (Root { root with value = v })
+;;
 
 let union t1 t2 =
   let t1, r1 = repr t1 in
   let t2, r2 = repr t2 in
-  if phys_equal t1 t2
+  if Transactional_store.Ref.equal t1 t2
   then ()
   else (
     let n1 = r1.rank in
     let n2 = r2.rank in
     if n1 < n2
-    then t1 := Inner t2
+    then Transactional_store.set t1 (Inner t2)
     else (
-      t2 := Inner t1;
-      if n1 = n2 then r1.rank <- r1.rank + 1))
+      Transactional_store.set t2 (Inner t1);
+      if n1 = n2 then Transactional_store.set t1 (Root { r1 with rank = r1.rank + 1 })))
 ;;
 
-let same_class t1 t2 = phys_equal (root t1) (root t2)
+let same_class t1 t2 = Transactional_store.Ref.equal (root t1) (root t2)
 
 let is_root t =
-  match !t with
+  match Transactional_store.get t with
   | Root _ -> true
   | Inner _ -> false
 ;;
+
+module Transaction = struct
+  let try_or_rollback = Transactional_store.try_or_rollback
+end

--- a/lib/std/union_find.mli
+++ b/lib/std/union_find.mli
@@ -38,3 +38,13 @@ val same_class : 'a t -> 'a t -> bool
 
 (** [is_root t] returns true if [t] is the root of an equivalence class *)
 val is_root : 'a t -> bool
+
+module Transaction : sig
+  (** [try_or_rollback ~f] performs [f ()] in a transaction on the transactional store 
+      the union-find data structure uses. If [f ()] raises an exception, then the 
+      transaction is aborted, and all union-find updates performed by [f] are 
+      rolled back. If [f ()] successfully returns, then the updates are committed.
+      
+      Safety: [f ()] cannot call [try_or_rollback]. *)
+  val try_or_rollback : f:(unit -> 'a) -> 'a
+end

--- a/lib/unifier/unifier.ml
+++ b/lib/unifier/unifier.ml
@@ -102,7 +102,10 @@ module Make (S : Structure.Basic) = struct
 
     let unify ~ctx t1 t2 =
       let work_queue = Work_queue.create () in
-      try unify_exn ~ctx ~work_queue t1 t2 with
+      try
+        Union_find.Transaction.try_or_rollback ~f:(fun () ->
+          unify_exn ~ctx ~work_queue t1 t2)
+      with
       | M.Cannot_merge -> raise (Unify (t1, t2))
     ;;
   end


### PR DESCRIPTION
Improves (some) error messages. In preparation for #45 where errors are often discovered after unification updates.