### PR TITLE
feat: add kinded(1) types

### DIFF
--- a/lib/constraint/constraint.mli
+++ b/lib/constraint/constraint.mli
@@ -1,3 +1,4 @@
+open Core
 open Mlsus_std
 open Grace
 
@@ -7,21 +8,32 @@ module Type : sig
   module Ident : Var.S
   module Var : Var.S
 
+  module Head : sig
+    (** [t] is the head of a type *)
+    type t =
+      | Arrow
+      | Tuple of int
+      | Constr of Ident.t
+    [@@deriving sexp]
+
+    include Comparable.S with type t := t
+  end
+
   module Matchee : sig
     (** [t] is a matchee, a partial (shallow) type that is matched on. *)
     type t =
-      | Arrow of Var.t * Var.t
-      | Tuple of Var.t list
-      | Constr of Var.t list * Ident.t
+      | App of Var.t * Var.t
+      | Head of Head.t
+      | Spine of Var.t list
       | Rigid_var
     [@@deriving sexp]
   end
 
   (** [t] represents the type [tau]. *)
   type t =
-    | Arrow of t * t (** [tau -> tau] *)
-    | Tuple of t list (** [tau1 * ... * taun] *)
-    | Constr of t list * Ident.t (** [(tau1, ..., taun) F] *)
+    | Head of Head.t (** [F] *)
+    | App of t * t (** [tau1 tau2] where [tau1] is a spine and [tau2] is a head *)
+    | Spine of t list (** [(tau1, ..., taun)] is a spine *)
     | Var of Var.t (** [ɑ] *)
   [@@deriving sexp]
 
@@ -29,6 +41,8 @@ module Type : sig
   val ( @-> ) : t -> t -> t
   val constr : t list -> Ident.t -> t
   val tuple : t list -> t
+  val spine : t list -> t
+  val ( @% ) : t -> t -> t
 end
 
 module Var : Var.S

--- a/lib/constraint_solver/decoded_type.mli
+++ b/lib/constraint_solver/decoded_type.mli
@@ -1,15 +1,7 @@
 open! Import
 module G := Generalization
-module Var : Var.S
-module Ident = Constraint.Type.Ident
 
-type t =
-  | Var of Var.t
-  | Arrow of t * t
-  | Tuple of t list
-  | Constr of t list * Ident.t
-  | Mu of Var.t * t
-[@@deriving sexp]
+type t [@@deriving sexp]
 
 include Pretty_printer.S with type t := t
 

--- a/lib/constraint_solver/import.ml
+++ b/lib/constraint_solver/import.ml
@@ -2,6 +2,6 @@ include Core
 include Mlsus_std
 include Mlsus_constraint
 include Grace
-module Type_ident = Constraint.Type.Ident
+module Type_head = Constraint.Type.Head
 module Ppx_log_syntax = Async.Ppx_log_syntax
 module Unifier = Mlsus_unifier.Unifier

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -89,15 +89,11 @@ let rec gtype_of_type : state:State.t -> env:Env.t -> C.Type.t -> G.Type.t =
   let self = gtype_of_type ~state ~env in
   match type_ with
   | Var type_var -> Env.find_type_var env type_var
-  | Arrow (type1, type2) ->
-    G.create_former ~state ~curr_region:env.curr_region (Arrow (self type1, self type2))
-  | Tuple types ->
-    G.create_former ~state ~curr_region:env.curr_region (Tuple (List.map types ~f:self))
-  | Constr (args, constr) ->
-    G.create_former
-      ~state
-      ~curr_region:env.curr_region
-      (Constr (List.map args ~f:self, constr))
+  | App (type1, type2) ->
+    G.create_former ~state ~curr_region:env.curr_region (App (self type1, self type2))
+  | Spine types ->
+    G.create_former ~state ~curr_region:env.curr_region (Spine (List.map types ~f:self))
+  | Head hd -> G.create_former ~state ~curr_region:env.curr_region (Head hd)
 ;;
 
 let match_type : state:State.t -> env:Env.t -> G.Type.t G.R.t -> Env.t * C.Type.Matchee.t =
@@ -109,10 +105,10 @@ let match_type : state:State.t -> env:Env.t -> G.Type.t G.R.t -> Env.t * C.Type.
   in
   match former with
   | Rigid_var -> env, Rigid_var
-  | Structure (Tuple gtypes) ->
+  | Structure (Spine gtypes) ->
     let env, type_vars = match_types ~env gtypes in
-    env, Tuple type_vars
-  | Structure (Arrow (gtype1, gtype2)) ->
+    env, Spine type_vars
+  | Structure (App (gtype1, gtype2)) ->
     let type_var1 = C.Type.Var.create ~id_source:state.id_source () in
     let type_var2 = C.Type.Var.create ~id_source:state.id_source () in
     let env =
@@ -120,10 +116,8 @@ let match_type : state:State.t -> env:Env.t -> G.Type.t G.R.t -> Env.t * C.Type.
       |> Env.bind_type_var ~var:type_var1 ~type_:gtype1
       |> Env.bind_type_var ~var:type_var2 ~type_:gtype2
     in
-    env, Arrow (type_var1, type_var2)
-  | Structure (Constr (gtypes, constr)) ->
-    let env, type_vars = match_types ~env gtypes in
-    env, Constr (type_vars, constr)
+    env, App (type_var1, type_var2)
+  | Structure (Head hd) -> env, Head hd
 ;;
 
 let forall ~(state : State.t) ~env ~type_var =

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -945,8 +945,10 @@ let%expect_test "" =
           (Exists ((id 2) (name Type.Var))
            (Conj
             (Eq (Var ((id 0) (name Type.Var)))
-             (Arrow (Var ((id 1) (name Type.Var)))
-              (Var ((id 2) (name Type.Var)))))
+             (App
+              (Spine
+               ((Var ((id 1) (name Type.Var))) (Var ((id 2) (name Type.Var)))))
+              (Head Arrow)))
             (With_range
              (Conj True
               (Let ((id 3) (name x))


### PR DESCRIPTION
This adds a restriction of higher-kinded types to mlsus. This extension to first-order types / unification permits us to match on the head of the type instead of the entire type. 

The benefit of this is that the head of the type can be shared between all instances of a type (by lowering the head's level). This permits propagation of type information from instances to suspended match constraints (provided the head isn't generic).