### PR TITLE
feat: add lower constraint

### DIFF
--- a/lib/constraint/constraint.ml
+++ b/lib/constraint/constraint.ml
@@ -68,6 +68,7 @@ type t =
   | Conj of t * t
   | Eq of Type.t * Type.t
   | Exists of Type.Var.t * t
+  | Lower of Type.Var.t
   | Let of Var.t * scheme * t
   | Instance of Var.t * Type.t
   | Match of
@@ -103,6 +104,7 @@ let all ts =
 let ( =~ ) type1 type2 = Eq (type1, type2)
 let exists type_var t = Exists (type_var, t)
 let exists_many vars in_ = List.fold_right vars ~init:in_ ~f:exists
+let lower t = Lower t
 let ( #= ) x scheme = x, scheme
 let mono_scheme type_ = { type_vars = []; in_ = tt; type_ }
 let ( @=> ) t1 t2 = t1, t2

--- a/lib/constraint/constraint.mli
+++ b/lib/constraint/constraint.mli
@@ -58,6 +58,7 @@ type t =
   | Conj of t * t (** [C1 /\ C2] *)
   | Eq of Type.t * Type.t (** [tau1 = tau2] *)
   | Exists of Type.Var.t * t (** [exists overline(a). C]*)
+  | Lower of Type.Var.t (** [lower(a)] *)
   | Let of Var.t * scheme * t (** [let x = sigma in C] *)
   | Instance of Var.t * Type.t (** [x <= tau] *)
   | Match of
@@ -87,6 +88,7 @@ val all : t list -> t
 val ( =~ ) : Type.t -> Type.t -> t
 val exists : Type.Var.t -> t -> t
 val exists_many : Type.Var.t list -> t -> t
+val lower : Type.Var.t -> t
 val ( #= ) : Var.t -> scheme -> Var.t * scheme
 
 type unquantified_scheme := t * Type.t

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -79,6 +79,12 @@ module Env = struct
     in
     { (empty ~range ~curr_region) with type_vars }
   ;;
+
+  let prev_region t =
+    match t.curr_region.parent with
+    | None -> t.curr_region
+    | Some parent -> parent
+  ;;
 end
 
 let rec gtype_of_type : state:State.t -> env:Env.t -> C.Type.t -> G.Type.t =
@@ -190,6 +196,12 @@ let rec solve : state:State.t -> env:Env.t -> C.t -> unit =
     [%log.global.debug "Updated env" (env : Env.t)];
     [%log.global.debug "Solving exist body"];
     self ~state ~env cst
+  | Lower type_var ->
+    let gtype = Env.find_type_var env type_var in
+    [%log.global.debug "Type to be lowered" (gtype : Type.t)];
+    let prev_region = Env.prev_region env in
+    [%log.global.debug "Prev region" (prev_region : Type.sexp_identifier_region_node)];
+    Type.set_region gtype prev_region
   | Match { matchee; closure; case = f; else_ } ->
     let matchee = Env.find_type_var env matchee in
     [%log.global.debug "Matchee type" (matchee : Type.t)];

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -853,9 +853,11 @@ let%expect_test "" =
              (Conj
               (Instance ((id 7) (name Constraint.Var))
                (Var ((id 5) (name Type.Var))))
-              (Eq (Var ((id 0) (name Type.Var))) (Constr () ((id 0) (name int)))))
+              (Eq (Var ((id 0) (name Type.Var)))
+               (App (Spine ()) (Head (Constr ((id 0) (name int)))))))
              (Instance ((id 7) (name Constraint.Var))
               (Var ((id 6) (name Type.Var)))))
-            (Eq (Var ((id 4) (name Type.Var))) (Constr () ((id 0) (name int))))))))))))
+            (Eq (Var ((id 4) (name Type.Var)))
+             (App (Spine ()) (Head (Constr ((id 0) (name int))))))))))))))
     |}]
 ;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -909,20 +909,14 @@ let%expect_test "" =
         | L 
       ;; 
 
-      let bad = 
+      let good = 
         let f = fun x -> match x with (L -> 1) in 
         f (L : m)
       ;; 
     |}
   in
   type_check_and_print str;
-  [%expect
-    {|
-    error[E011]: mismatched type
-        ┌─ expect_test.ml:12:11
-     12 │          f (L : m)
-        │            ^^^^^^^ `n` is not equal to `m`
-    |}]
+  [%expect {| Well typed :) |}]
 ;;
 
 let%expect_test "" =

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -262,6 +262,7 @@ struct
       let spine_type = Type.Var.create ~id_source:(Env.id_source env) () in
       exists_many [ hd_type; spine_type ]
       @@ (Type.(var ret =~ var spine_type @% var hd_type)
+          &~ lower hd_type
           &~ match_
                hd_type
                ~closure:([ ret ] @ X.arg_closure arg)


### PR DESCRIPTION
This PR adds a new constraint `lower('a)` which ensures that `'a` is monomorphic by lowering it to the parent region. 

This is useful for sharing a suspended constraint between instances, allowing the following program to be well-typed
```ocaml
      type m = 
        | L 
      ;;

      type n = 
        | L 
      ;; 

      let good = 
        let f = fun x -> match x with (L -> 1) in 
        f (L : m)
      ;; 
   ```
