### PR TITLE
feat(type_checker): make the default disambiguation cheaper

### DIFF
--- a/lib/constraint/constraint.ml
+++ b/lib/constraint/constraint.ml
@@ -50,6 +50,7 @@ module Type = struct
   let tuple ts = App (Spine ts, Head (Tuple (List.length ts)))
   let spine ts = Spine ts
   let ( @% ) t1 t2 = App (t1, t2)
+  let hd h = Head h
 end
 
 module Var = Var.Make (struct

--- a/lib/constraint/constraint.mli
+++ b/lib/constraint/constraint.mli
@@ -43,6 +43,7 @@ module Type : sig
   val tuple : t list -> t
   val spine : t list -> t
   val ( @% ) : t -> t -> t
+  val hd : Head.t -> t
 end
 
 module Var : Var.S

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -265,7 +265,7 @@ struct
           &~ lower hd_type
           &~ match_
                hd_type
-               ~closure:([ ret ] @ X.arg_closure arg)
+               ~closure:([ ret; hd_type ] @ X.arg_closure arg)
                ~with_:(function
                  | App _ | Spine _ -> assert false
                  | (Head (Arrow | Tuple _) | Rigid_var) as matchee ->
@@ -281,7 +281,9 @@ struct
                         ~range:name.range
                         ~type_head)
                  | Head (Constr type_ident) -> disambiguate_and_infer type_ident)
-               ~else_:(fun () -> disambiguate_and_infer (X.ident (List.hd_exn defs))))
+               ~else_:(fun () ->
+                 let default_type_ident = X.ident (List.hd_exn defs) in
+                 Type.(var hd_type =~ hd (Constr default_type_ident))))
   ;;
 end
 


### PR DESCRIPTION
This PR unifies the head of the type in the default case of constructor/label disambiguation (instead of using `disambiguation_and_infer`)