### PR TITLE
fix(solver): update invariants for generalization

### DIFF
--- a/lib/constraint_solver/tree.ml
+++ b/lib/constraint_solver/tree.ml
@@ -54,36 +54,4 @@ let rec nearest_common_ancestor t1 t2 =
       (Option.value_exn ~here:[%here] t2.parent))
 ;;
 
-module Path = struct
-  type 'a t =
-    { dst : 'a node
-    ; compare_node_by_level : 'a node -> 'a node -> int
-    ; mem : 'a node -> bool
-    }
-  [@@deriving sexp_of]
-
-  let of_node dst =
-    let node_by_level = Hashtbl.create (module Level) in
-    let rec populate_levels node =
-      Hashtbl.set node_by_level ~key:node.level ~data:node;
-      match node.parent with
-      | None -> ()
-      | Some parent_node -> populate_levels parent_node
-    in
-    populate_levels dst;
-    let mem node =
-      match Hashtbl.find_exn node_by_level node.level with
-      | exception Not_found_s _ -> false
-      | node' -> Identifier.(node.id = node'.id)
-    in
-    let compare_node_by_level n1 n2 =
-      assert (mem n1 && mem n2);
-      Level.compare n1.level n2.level
-    in
-    { dst; mem; compare_node_by_level }
-  ;;
-
-  let compare_node_by_level t n1 n2 = t.compare_node_by_level n1 n2 [@@inline]
-  let mem t n = t.mem n [@@inline]
-  let dst t = t.dst [@@inline]
-end
+let compare_node_by_level n1 n2 = Level.compare n1.level n2.level [@@inline]

--- a/lib/constraint_solver/tree.mli
+++ b/lib/constraint_solver/tree.mli
@@ -34,19 +34,5 @@ val create_node : id_source:Identifier.source -> parent:'a node -> 'a -> 'a node
 (** [nearest_common_ancestor n1 n2] returns the nearest common ancestor of two nodes in a tree *)
 val nearest_common_ancestor : 'a node -> 'a node -> 'a node
 
-module Path : sig
-  (** A (linear) path in the tree from the root to a given node *)
-  type 'a t [@@deriving sexp_of]
-
-  (** [of_node n] returns a path from the tree root to the node [n] *)
-  val of_node : 'a node -> 'a t
-
-  (** [compare_node_by_level p] is a total ordering on nodes in the path [p] *)
-  val compare_node_by_level : 'a t -> 'a node -> 'a node -> int
-
-  (** [mem p n] returns whether the node [n] is in the path [p] *)
-  val mem : 'a t -> 'a node -> bool
-
-  (** [dst p] returns the destination node of the path [p] *)
-  val dst : 'a t -> 'a node
-end
+(** [compare_node_by_level n1 n2] is [Level.compare n1.level n2.level]. *)
+val compare_node_by_level : 'a node -> 'a node -> int


### PR DESCRIPTION
# Context

When generalizing a region, it is possible to access a variable in a sibling / cousin region, but only when this variable will eventually be lowered to a parent region. 

# Changes

We previously asserted that this was impossible. But it is in fact possible (the comment in `generalization.ml` details such a scenario). The fix is to remove the `assert` conditions in `update_type_levels`. 