### PR TITLE
feat: add support for higher-rank poly

### DIFF
--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -8,7 +8,7 @@ type core_type = core_type_desc With_range.t
 
 and core_type_desc =
   | Type_var of Type_var_name.With_range.t
-  | Type_arrow of param_type * core_type
+  | Type_arrow of param_type * return_type
   | Type_tuple of core_type list
   | Type_constr of core_type list * Type_name.With_range.t
   | Type_poly of core_scheme
@@ -18,6 +18,12 @@ and param_type = param_type_desc With_range.t
 and param_type_desc =
   | Param_mono_type of core_type
   | Param_poly_type of core_scheme
+
+and return_type = return_type_desc With_range.t
+
+and return_type_desc =
+  | Return_mono_type of core_type
+  | Return_poly_type of core_scheme
 
 and core_scheme = core_scheme_desc With_range.t
 
@@ -55,7 +61,7 @@ type expression = expression_desc With_range.t
 and expression_desc =
   | Exp_var of Var_name.With_range.t
   | Exp_const of constant
-  | Exp_fun of function_param list * expression
+  | Exp_fun of function_param list * return_type option * expression
   | Exp_app of expression * expression
   | Exp_let of value_binding * expression
   | Exp_exists of Type_var_name.With_range.t list * expression

--- a/lib/ast/ast_builder.ml
+++ b/lib/ast/ast_builder.ml
@@ -21,8 +21,13 @@ module type S = sig
       val poly : (core_scheme -> param_type) with_range_fn
     end
 
+    module Function_return : sig
+      val mono : (core_type -> return_type) with_range_fn
+      val poly : (core_scheme -> return_type) with_range_fn
+    end
+
     val var : (Type_var_name.With_range.t -> core_type) with_range_fn
-    val arrow : (param_type -> core_type -> core_type) with_range_fn
+    val arrow : (param_type -> return_type -> core_type) with_range_fn
     val tuple : (core_type list -> core_type) with_range_fn
     val constr : (core_type list -> Type_name.With_range.t -> core_type) with_range_fn
     val poly : (core_scheme -> core_type) with_range_fn
@@ -54,7 +59,11 @@ module type S = sig
 
     val var : (Var_name.With_range.t -> expression) with_range_fn
     val const : (constant -> expression) with_range_fn
-    val fun_ : (function_param list -> expression -> expression) with_range_fn
+
+    val fun_
+      : (function_param list -> ?return_type:return_type -> expression -> expression)
+          with_range_fn
+
     val app : (expression -> expression -> expression) with_range_fn
     val let_ : (value_binding -> in_:expression -> expression) with_range_fn
 
@@ -124,6 +133,11 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
       let poly ~range poly_type = With_range.create ~range @@ Param_poly_type poly_type
     end
 
+    module Function_return = struct
+      let mono ~range mono_type = With_range.create ~range @@ Return_mono_type mono_type
+      let poly ~range poly_type = With_range.create ~range @@ Return_poly_type poly_type
+    end
+
     let var ~range type_var_name = With_range.create ~range @@ Type_var type_var_name
     let arrow ~range type1 type2 = With_range.create ~range @@ Type_arrow (type1, type2)
     let tuple ~range types = With_range.create ~range @@ Type_tuple types
@@ -165,7 +179,11 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
 
     let var ~range var_name = With_range.create ~range @@ Exp_var var_name
     let const ~range const = With_range.create ~range @@ Exp_const const
-    let fun_ ~range pats exp = With_range.create ~range @@ Exp_fun (pats, exp)
+
+    let fun_ ~range pats ?return_type exp =
+      With_range.create ~range @@ Exp_fun (pats, return_type, exp)
+    ;;
+
     let app ~range exp1 exp2 = With_range.create ~range @@ Exp_app (exp1, exp2)
 
     let let_ ~range value_binding ~in_ =
@@ -243,6 +261,11 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
     module Function_param = struct
       let mono = Type.Function_param.mono ~range:R.v
       let poly = Type.Function_param.poly ~range:R.v
+    end
+
+    module Function_return = struct
+      let mono = Type.Function_return.mono ~range:R.v
+      let poly = Type.Function_return.poly ~range:R.v
     end
 
     let var = Type.var ~range:R.v

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -1001,7 +1001,9 @@ module Suspended_match = struct
     List.iter variables ~f:(Type.add_guard ~state);
     List.iter schemes ~f:(fun scheme ->
       (* TODO: We should propably force the generalization of the scheme here *)
-      Scheme.iter_instances_and_partial_generics scheme ~f:(Type.add_guard ~state))
+      [%log.global.debug "Guarding scheme" (scheme : Scheme.t)];
+      Scheme.iter_instances_and_partial_generics scheme ~f:(Type.add_guard ~state);
+      [%log.global.debug "Guarded scheme" (scheme : Scheme.t)])
   ;;
 
   let closure_remove_guard ~state ~shape_args { variables; schemes } =
@@ -1060,13 +1062,13 @@ module Suspended_match = struct
         { run =
             (fun shape ->
               let args = get_or_alloc_matchee_args () in
-              (* Remove guard from closure *)
-              closure_remove_guard ~state ~shape_args closure;
               (* Solve case *)
               case ~curr_region ~shape ~args;
               [%log.global.debug
                 "Generalization tree after solving case"
-                  (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
+                  (state.region_tree : Type.t Pool.t Tree.With_dirty.t)];
+              (* Remove guard from closure *)
+              closure_remove_guard ~state ~shape_args closure)
         ; default =
             (fun () ->
               [%log.global.debug

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -208,7 +208,7 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     [%log.global.debug
       "Instantiating scheme" (var : Constraint.Var.t) (var_gscheme : G.Scheme.t)];
     let actual_gtype = G.instantiate ~state ~curr_region:env.curr_region var_gscheme in
-    [%log.global.debug "Scheme instance" (actual_gtype : G.Type.t)];
+    [%log.global.debug "Scheme instance" (var_gscheme : G.Scheme.t) (actual_gtype : G.Type.t)];
     unify ~state ~env actual_gtype expected_gtype
   | Exists (type_var, cst) ->
     [%log.global.debug "Binding unification for type_var" (type_var : Type.Var.t)];

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -208,7 +208,8 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     [%log.global.debug
       "Instantiating scheme" (var : Constraint.Var.t) (var_gscheme : G.Scheme.t)];
     let actual_gtype = G.instantiate ~state ~curr_region:env.curr_region var_gscheme in
-    [%log.global.debug "Scheme instance" (var_gscheme : G.Scheme.t) (actual_gtype : G.Type.t)];
+    [%log.global.debug
+      "Scheme instance" (var_gscheme : G.Scheme.t) (actual_gtype : G.Type.t)];
     unify ~state ~env actual_gtype expected_gtype
   | Exists (type_var, cst) ->
     [%log.global.debug "Binding unification for type_var" (type_var : Type.Var.t)];

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -851,9 +851,9 @@ let%expect_test "" =
     error[E011]: mismatched type
         ┌─ expect_test.ml:3:9
       3 │          (x, x) (fun y -> y)
-        │          ^^^^^^ `'a -> 'b`
+        │          ^^^^^^ `'a * 'a`
         │                   is not equal to
-        │                 `'c * 'd`
+        │                 `'b -> 'c`
     |}];
   type_check_and_print ~with_poly_params:true ~defaulting:Unary str;
   [%expect
@@ -861,9 +861,9 @@ let%expect_test "" =
     error[E011]: mismatched type
         ┌─ expect_test.ml:3:9
       3 │          (x, x) (fun y -> y)
-        │          ^^^^^^ `'a -> 'b`
+        │          ^^^^^^ `'a * 'b`
         │                   is not equal to
-        │                 `'c * 'd`
+        │                 `'c -> 'd`
     |}]
 ;;
 
@@ -1036,9 +1036,11 @@ let%expect_test "" =
           (Exists ((id 1) (name Type.Var))
            (Exists ((id 2) (name Type.Var))
             (Conj
-             (Eq (Var ((id 0) (name Type.Var)))
-              (Arrow (Var ((id 1) (name Type.Var)))
-               (Var ((id 2) (name Type.Var)))))
+             (Conj
+              (Eq (Var ((id 0) (name Type.Var)))
+               (Arrow (Var ((id 1) (name Type.Var)))
+                (Var ((id 2) (name Type.Var)))))
+              True)
              (Conj
               (With_range True
                ((start 20) (stop 21)
@@ -1926,11 +1928,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:25:27
+        ┌─ expect_test.ml:25:29
      25 │        let xignore = poly1 [(fun x -> x + 1)];;
-        │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
-        │                                                 is not equal to
-        │                                               `'a -> 'a`
+        │                              ^^^^^^^^^^^^^^ `int -> int`
+        │                                               is not equal to
+        │                                             `'a -> 'a`
     |}];
   do_test
     ~add:true
@@ -1958,9 +1960,9 @@ let%expect_test "" =
   [%expect
     {|
     error[E012]: generic type variable escapes its scope
-        ┌─ expect_test.ml:28:35
+        ┌─ expect_test.ml:28:37
      28 │        let escape = fun f -> poly1 [(fun x -> f x; x)];;
-        │                                    ^^^^^^^^^^^^^^^^^^^
+        │                                      ^^^^^^^^^^^^^^^
     |}];
   do_test
     ~add:true
@@ -1983,11 +1985,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:33:27
+        ┌─ expect_test.ml:33:29
      33 │        let xignore = poly2 [(fun x -> x + 1)];;
-        │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
-        │                                                 is not equal to
-        │                                               `'a -> 'a`
+        │                              ^^^^^^^^^^^^^^ `int -> int`
+        │                                               is not equal to
+        │                                             `'a -> 'a`
     |}];
   do_test
     ~add:true
@@ -2013,11 +2015,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:41:27
+        ┌─ expect_test.ml:41:29
      41 │        let xignore = poly3 [(fun x -> x + 1)] [8];;
-        │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
-        │                                                 is not equal to
-        │                                               `'a -> 'a`
+        │                              ^^^^^^^^^^^^^^ `int -> int`
+        │                                               is not equal to
+        │                                             `'a -> 'a`
     |}];
   do_test
     ~add:true
@@ -2041,11 +2043,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:47:34
+        ┌─ expect_test.ml:47:36
      47 │        let xignore = poly4 [true] [(fun x -> x + 1)];;
-        │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
-        │                                                        is not equal to
-        │                                                      `'a -> 'a`
+        │                                     ^^^^^^^^^^^^^^ `int -> int`
+        │                                                      is not equal to
+        │                                                    `'a -> 'a`
     |}];
   do_test
     ~add:true
@@ -2069,11 +2071,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:53:34
+        ┌─ expect_test.ml:53:36
      53 │        let xignore = poly5 [true] [(fun x -> x + 1)];;
-        │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
-        │                                                        is not equal to
-        │                                                      `'a -> 'a`
+        │                                     ^^^^^^^^^^^^^^ `int -> int`
+        │                                                      is not equal to
+        │                                                    `'a -> 'a`
     |}];
   do_test
     ~add:true
@@ -2100,11 +2102,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:62:34
+        ┌─ expect_test.ml:62:36
      62 │        let xignore = poly6 [true] [(fun x -> x + 1)] [8];;
-        │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
-        │                                                        is not equal to
-        │                                                      `'a -> 'a`
+        │                                     ^^^^^^^^^^^^^^ `int -> int`
+        │                                                      is not equal to
+        │                                                    `'a -> 'a`
     |}];
   do_test
     ~add:true
@@ -2122,11 +2124,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:67:33
+        ┌─ expect_test.ml:67:35
      67 │        let xignore = needs_magic [(fun x -> x)];;
-        │                                  ^^^^^^^^^^^^^^ `'a -> 'a`
-        │                                                   is not equal to
-        │                                                 `'b -> 'c`
+        │                                    ^^^^^^^^^^ `'a -> 'a`
+        │                                                 is not equal to
+        │                                               `'b -> 'c`
     |}];
   do_test
     ~add:true
@@ -3656,7 +3658,7 @@ let%expect_test "" =
   do_test
     {|
       external r : (forall 'a. 'a -> (forall 'b. 'b -> 'b)) -> int;;
-      let _ = r (fun x -> fun y -> y);;
+      let _ = r (fun x y -> y);;
     |};
   [%expect {| Well typed :) |}]
 ;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -176,7 +176,8 @@ let%expect_test "" =
   type_check_and_print str;
   [%expect {| Well typed :) |}];
   type_check_and_print ~with_poly_params:true ~defaulting:Unary str;
-  [%expect {| Well typed :) |}]
+  [%expect
+    {| bug[E???]: lib/constraint_solver/generalization.ml:71:24: "Status.is_dirty Generic is undefined" |}]
 ;;
 
 let%expect_test "" =
@@ -795,7 +796,8 @@ let%expect_test "" =
   type_check_and_print str;
   [%expect {| Well typed :) |}];
   type_check_and_print ~with_poly_params:true ~defaulting:Unary str;
-  [%expect {| Well typed :) |}]
+  [%expect
+    {| bug[E???]: lib/constraint_solver/generalization.ml:71:24: "Status.is_dirty Generic is undefined" |}]
 ;;
 
 let%expect_test "" =
@@ -1674,9 +1676,11 @@ let%expect_test "" =
     error[E011]: mismatched type
         ┌─ expect_test.ml:4:33
       4 │        let see_pid1 = (fun x -> (@[x], @[x])) pid1 ;;
-        │                                  ^^^^ `('a * 'b) @(ν'a. [∀. 'a]) -> 'a * 'b`
+        │                                  ^^^^ `('a * 'b) @(ν'a. [∀. 'a]) ->
+        │                                        ('a * 'b) @(ν'a. [∀. 'a])`
         │                                         is not equal to
-        │                                       `('c * 'd) @(ν'a. [∀. 'a]) -> 'c * 'd`
+        │                                       `('c * 'd) @(ν'a. [∀. 'a]) ->
+        │                                        ('c * 'd) @(ν'a. [∀. 'a])`
     |}]
 ;;
 
@@ -1807,11 +1811,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:3:19
-      3 │        let pid = [ succ : 'a. 'a -> 'a ] ;;
-        │                    ^^^^ `'a -> int`
-        │                           is not equal to
-        │                         `'b @(ν'a. [∀. 'a]) -> 'b`
+        ┌─ expect_test.ml:2:27
+      2 │        let succ = fun x -> x + 1 ;;
+        │                            ^^^^^ `int`
+        │                                    is not equal to
+        │                                  `'a`
     |}]
 ;;
 
@@ -2247,11 +2251,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:24:28
+        ┌─ expect_test.ml:24:37
      24 │        let xignore = poly1 (fun x -> x + 1);;
-        │                             ^^^^^^^^^^^^^^ `'a -> int`
+        │                                      ^^^^^ `int`
         │                                              is not equal to
-        │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
+        │                                            `'a`
     |}];
   do_test
     ~add:true
@@ -2308,11 +2312,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:30:28
+        ┌─ expect_test.ml:30:37
      30 │        let xignore = poly2 (fun x -> x + 1);;
-        │                             ^^^^^^^^^^^^^^ `'a -> int`
+        │                                      ^^^^^ `int`
         │                                              is not equal to
-        │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
+        │                                            `'a`
     |}];
   do_test
     ~add:true
@@ -2336,11 +2340,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:36:28
+        ┌─ expect_test.ml:36:37
      36 │        let xignore = poly3 (fun x -> x + 1) 8;;
-        │                             ^^^^^^^^^^^^^^ `'a -> int`
+        │                                      ^^^^^ `int`
         │                                              is not equal to
-        │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
+        │                                            `'a`
     |}];
   do_test
     ~add:true
@@ -2362,11 +2366,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:40:33
+        ┌─ expect_test.ml:40:42
      40 │        let xignore = poly4 true (fun x -> x + 1);;
-        │                                  ^^^^^^^^^^^^^^ `'a -> int`
+        │                                           ^^^^^ `int`
         │                                                   is not equal to
-        │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
+        │                                                 `'a`
     |}];
   do_test
     ~add:true
@@ -2388,11 +2392,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:44:33
+        ┌─ expect_test.ml:44:42
      44 │        let xignore = poly5 true (fun x -> x + 1);;
-        │                                  ^^^^^^^^^^^^^^ `'a -> int`
+        │                                           ^^^^^ `int`
         │                                                   is not equal to
-        │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
+        │                                                 `'a`
     |}];
   do_test
     ~add:true
@@ -2416,11 +2420,11 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:50:33
+        ┌─ expect_test.ml:50:42
      50 │        let xignore = poly6 true (fun x -> x + 1) 8;;
-        │                                  ^^^^^^^^^^^^^^ `'a -> int`
+        │                                           ^^^^^ `int`
         │                                                   is not equal to
-        │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
+        │                                                 `'a`
     |}];
   do_test
     ~add:true
@@ -3077,14 +3081,14 @@ let%expect_test "" =
   [%expect
     {|
     error[E010]: ambiguous constructor
-        ┌─ expect_test.ml:14:20
-     14 │            unify x (Foo (y));
+        ┌─ expect_test.ml:15:20
+     15 │            unify y (Foo (x))
         │                     ^^^
         = hint: add a type annotation
 
     error[E010]: ambiguous constructor
-        ┌─ expect_test.ml:15:20
-     15 │            unify y (Foo (x))
+        ┌─ expect_test.ml:14:20
+     14 │            unify x (Foo (y));
         │                     ^^^
         = hint: add a type annotation
     |}]
@@ -3213,6 +3217,12 @@ let%expect_test "" =
         ┌─ expect_test.ml:2:26
       2 │        let _ = fun f -> f f;;
         │                           ^
+        = hint: add a type annotation
+
+    error[E016]: unknown polytype
+        ┌─ expect_test.ml:2:24
+      2 │        let _ = fun f -> f f;;
+        │                         ^^^
         = hint: add a type annotation
     |}]
 ;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -176,8 +176,7 @@ let%expect_test "" =
   type_check_and_print str;
   [%expect {| Well typed :) |}];
   type_check_and_print ~with_poly_params:true ~defaulting:Unary str;
-  [%expect
-    {| bug[E???]: lib/constraint_solver/generalization.ml:71:24: "Status.is_dirty Generic is undefined" |}]
+  [%expect {| Well typed :) |}]
 ;;
 
 let%expect_test "" =
@@ -796,8 +795,7 @@ let%expect_test "" =
   type_check_and_print str;
   [%expect {| Well typed :) |}];
   type_check_and_print ~with_poly_params:true ~defaulting:Unary str;
-  [%expect
-    {| bug[E???]: lib/constraint_solver/generalization.ml:71:24: "Status.is_dirty Generic is undefined" |}]
+  [%expect {| Well typed :) |}]
 ;;
 
 let%expect_test "" =
@@ -3225,4 +3223,440 @@ let%expect_test "" =
         │                         ^^^
         = hint: add a type annotation
     |}]
+;;
+
+let%expect_test "" =
+  (* All examples from https://dl.acm.org/doi/pdf/10.1145/3408971 *)
+  let test =
+    Incremental_test.create
+      ~initial:
+        (include_list
+         ^ {|
+              external head : 'a. 'a list -> 'a;;
+              external tail : 'a. 'a list -> 'a list;;
+              external nil : 'a. 'a list;;
+              external cons : 'a. 'a -> 'a list -> 'a list;;
+              external single : 'a. 'a -> 'a list;;
+              external concat : 'a. 'a list -> 'a list -> 'a list;;
+              external length : 'a. 'a list -> int;;
+              external id : 'a. 'a -> 'a;;
+              external inc : int -> int;;
+              external choose : 'a. 'a -> 'a -> 'a;;
+              external poly : (forall 'a. 'a -> 'a) -> int * bool;;
+              external auto : (forall 'a. 'a -> 'a) -> (forall 'a. 'a -> 'a);;
+              external auto2 : 'b. (forall 'a. 'a -> 'a) -> 'b -> 'b;;
+              (* I've put ids in a polytype. Not too sure what we should do for this? *)
+              external ids : [ 'a. 'a -> 'a ] list;;
+              external map : 'a 'b. ('a -> 'b) -> 'a list -> 'b list;;
+              external app : 'a 'b. ('a -> 'b) -> 'a -> 'b;;
+              external revapp : 'a 'b. 'a -> ('a -> 'b) -> 'b;;
+              external flip : 'a 'b 'c. ('a -> 'b -> 'c) -> 'b -> 'a -> 'c;;
+
+              type ('s, 'a) st = 
+                | St 
+              ;;
+              
+              external run_st : 'v. (forall 's. ('s, 'v) st) -> 'v;;
+              external arg_st : 's. ('s, int) st;;
+           |}
+        )
+      (type_check_and_print ~with_poly_params:true ~defaulting:Unary)
+  in
+  let do_test = Incremental_test.run test in
+  (* A1 *)
+  do_test
+    {|
+      let const2 = fun x y -> y;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A2 *)
+  do_test
+    {|
+      let _ = choose id;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A3 : infers ['a. 'a -> 'a] list *)
+  do_test
+    {|
+      let _ = choose nil ids;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A4 *)
+  do_test
+    {|
+      let _ = fun (forall x : 'a. 'a -> 'a) -> x x;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A5 *)
+  do_test
+    {|
+      let _ = id auto;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A6 *)
+  do_test
+    {|
+      let _ = id auto2;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A7: fails because id actually has the type 'a. ['a] -> ['a]. *)
+  do_test
+    {|
+      let _ = choose id auto;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:25
+     34 │        let _ = choose id auto;;
+        │                          ^^^^ `@(ν.
+        │                                    [∀'a.
+        │                                       'a @(ν'a. [∀. 'a]) ->
+        │                                       'a @(ν'a. [∀. 'a])]) ->
+        │                                @(ν.
+        │                                    [∀'a.
+        │                                       'a @(ν'a. [∀. 'a]) ->
+        │                                       'a @(ν'a. [∀. 'a])])`
+        │                                 is not equal to
+        │                               `'a @(ν'a. [∀. 'a]) -> 'a @(ν'a. [∀. 'a])`
+    |}];
+  (* A8: fails for the same reason. *)
+  do_test
+    {|
+      let _ = choose id auto2;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:25
+     34 │        let _ = choose id auto2;;
+        │                          ^^^^^ `@(ν.
+        │                                     [∀'a.
+        │                                        'a @(ν'a. [∀. 'a]) ->
+        │                                        'a @(ν'a. [∀. 'a])]) ->
+        │                                 ('a @(ν'a. [∀. 'a]) ->
+        │                                  'a @(ν'a. [∀. 'a]))
+        │                                 @(ν'a. [∀. 'a])`
+        │                                  is not equal to
+        │                                `'b @(ν'a. [∀. 'a]) -> 'b @(ν'a. [∀. 'a])`
+    |}];
+  (* A9: fails because choose id becomes (['b] -> ['b]) -> (['b] -> ['b]). 
+         unifies 'a with ['b] -> ['b]. But ids is ['c. 'c -> 'c] list. 
+         'a cannot be unified with ['c. 'c -> 'c]. *)
+  do_test
+    {|
+      external f : 'a. ('a -> 'a) -> 'a list -> 'a;;
+      let _ = f (choose id) ids;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:35:29
+     35 │        let _ = f (choose id) ids;;
+        │                              ^^^ `(@(ν.
+        │                                        [∀'a.
+        │                                           'a @(ν'a. [∀. 'a]) ->
+        │                                           'a @(ν'a. [∀. 'a])]))
+        │                                   list`
+        │                                    is not equal to
+        │                                  `('a @(ν'a. [∀. 'a]) ->
+        │                                    'a @(ν'a. [∀. 'a]))
+        │                                   list`
+    |}];
+  (* A10 *)
+  do_test
+    {|
+      let _ = poly id;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A11 *)
+  do_test
+    {|
+      let _ = poly (fun x -> x);;
+    |};
+  [%expect {| Well typed :) |}];
+  (* A12 *)
+  do_test
+    {|
+      let _ = id poly (fun x -> x);;
+    |};
+  [%expect {| Well typed :) |}];
+  (* B1 *)
+  do_test
+    {|
+      let _ = fun f -> (f 1, f true);;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:27
+     34 │        let _ = fun f -> (f 1, f true);;
+        │                            ^ `int`
+        │                                is not equal to
+        │                              `bool`
+    |}];
+  do_test
+    {|
+      let _ = fun (forall f : 'a. 'a -> 'a) -> (f 1, f true);;
+    |};
+  [%expect {| Well typed :) |}];
+  (* B2 *)
+  do_test
+    {|
+      let _ = fun xs -> poly (head xs);;
+    |};
+  [%expect
+    {|
+    error[E012]: generic type variable escapes its scope
+        ┌─ expect_test.ml:34:31
+     34 │        let _ = fun xs -> poly (head xs);;
+        │                                ^^^^^^^
+    |}];
+  (* C1 *)
+  do_test
+    {|
+      let _ = length ids;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* C2 *)
+  do_test
+    {|
+      let _ = tail ids;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* C2 *)
+  do_test
+    {|
+      let _ = head ids;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* C3 *)
+  do_test
+    {|
+      let _ = single id;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* C4: fails because id is instantiated. *)
+  do_test
+    {|
+      let _ = cons id ids;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:23
+     34 │        let _ = cons id ids;;
+        │                        ^^^ `(@(ν.
+        │                                  [∀'a.
+        │                                     'a @(ν'a. [∀. 'a]) ->
+        │                                     'a @(ν'a. [∀. 'a])]))
+        │                             list`
+        │                              is not equal to
+        │                            `('a @(ν'a. [∀. 'a]) -> 'a @(ν'a. [∀. 'a]))
+        │                             list`
+    |}];
+  (* C5 *)
+  do_test
+    {|
+      let _ = cons (fun x -> x) ids;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:33
+     34 │        let _ = cons (fun x -> x) ids;;
+        │                                  ^^^ `(@(ν.
+        │                                            [∀'a.
+        │                                               'a @(ν'a. [∀. 'a]) ->
+        │                                               'a @(ν'a. [∀. 'a])]))
+        │                                       list`
+        │                                        is not equal to
+        │                                      `('a -> 'b) list`
+    |}];
+  (* C7 *)
+  do_test
+    {|
+      let _ = concat (single inc) (single id);;
+    |};
+  [%expect {| Well typed :) |}];
+  (* C8 *)
+  do_test
+    {|
+      external g : 'a. 'a list -> 'a list -> 'a;;
+      let _ = g (single id) ids;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:35:29
+     35 │        let _ = g (single id) ids;;
+        │                              ^^^ `(@(ν.
+        │                                        [∀'a.
+        │                                           'a @(ν'a. [∀. 'a]) ->
+        │                                           'a @(ν'a. [∀. 'a])]))
+        │                                   list`
+        │                                    is not equal to
+        │                                  `('a @(ν'a. [∀. 'a]) ->
+        │                                    'a @(ν'a. [∀. 'a]))
+        │                                   list`
+    |}];
+  (* C9 *)
+  do_test
+    {|
+      let _ = map poly (single id);;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:19
+     34 │        let _ = map poly (single id);;
+        │                    ^^^^ `@(ν.
+        │                              [∀'a.
+        │                                 'a @(ν'a. [∀. 'a]) -> 'a @(ν'a. [∀. 'a])]) ->
+        │                          (int * bool) @(ν'a. [∀. 'a])`
+        │                           is not equal to
+        │                         `'a @(ν'a. [∀. 'a]) -> 'b @(ν'a. [∀. 'a])`
+    |}];
+  (* C10 *)
+  do_test
+    {|
+      let _ = map head (single ids);;
+    |};
+  [%expect {| Well typed :) |}];
+  (* D0 *)
+  do_test
+    {|
+      let _ = poly id;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* D1 *)
+  do_test
+    {|
+      let _ = app poly id;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:19
+     34 │        let _ = app poly id;;
+        │                    ^^^^ `@(ν.
+        │                              [∀'a.
+        │                                 'a @(ν'a. [∀. 'a]) -> 'a @(ν'a. [∀. 'a])]) ->
+        │                          (int * bool) @(ν'a. [∀. 'a])`
+        │                           is not equal to
+        │                         `'a @(ν'a. [∀. 'a]) -> 'b @(ν'a. [∀. 'a])`
+    |}];
+  (* D2 *)
+  do_test
+    {|
+      let _ = revapp id poly;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:25
+     34 │        let _ = revapp id poly;;
+        │                          ^^^^ `@(ν.
+        │                                    [∀'a.
+        │                                       'a @(ν'a. [∀. 'a]) ->
+        │                                       'a @(ν'a. [∀. 'a])]) ->
+        │                                (int * bool) @(ν'a. [∀. 'a])`
+        │                                 is not equal to
+        │                               `('a @(ν'a. [∀. 'a]) -> 'a @(ν'a. [∀. 'a]))
+        │                                @(ν'a. [∀. 'a]) -> 'b @(ν'a. [∀. 'a])`
+    |}];
+  (* D3 *)
+  do_test
+    {|
+      let _ = run_st arg_st;;
+    |};
+  [%expect {| Well typed :) |}];
+  (* D4 *)
+  do_test
+    {|
+      let _ = app run_st arg_st;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:19
+     34 │        let _ = app run_st arg_st;;
+        │                    ^^^^^^ `'a @(ν'b. [∀'a. ('a, 'b) st]) ->
+        │                            'a @(ν'a. [∀. 'a])`
+        │                             is not equal to
+        │                           `'b @(ν'a. [∀. 'a]) -> 'c @(ν'a. [∀. 'a])`
+    |}];
+  (* D5 *)
+  do_test
+    {|
+      let _ = revapp arg_st run_st;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:34:29
+     34 │        let _ = revapp arg_st run_st;;
+        │                              ^^^^^^ `'a @(ν'b. [∀'a. ('a, 'b) st]) ->
+        │                                      'a @(ν'a. [∀. 'a])`
+        │                                       is not equal to
+        │                                     `(('b, int) st) @(ν'a. [∀. 'a]) ->
+        │                                      'c @(ν'a. [∀. 'a])`
+    |}];
+  (* E1 *)
+  do_test
+    {|
+      external h : int -> (forall 'a. 'a -> 'a);;
+      external k : 'a. 'a -> 'a list -> 'a;;
+      external lst : ['a. int -> 'a -> 'a] list;;
+      let _ = k h lst;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:37:19
+     37 │        let _ = k h lst;;
+        │                    ^^^ `(((int) @(ν'a. [∀. 'a]))
+        │                          @(ν'b.
+        │                              [∀'a.
+        │                                 'b ->
+        │                                 ('a @(ν'a. [∀. 'a]) ->
+        │                                  'a @(ν'a. [∀. 'a]))
+        │                                 @(ν'a. [∀. 'a])]))
+        │                         list`
+        │                          is not equal to
+        │                        `((int) @(ν'a. [∀. 'a]) ->
+        │                          @(ν.
+        │                              [∀'a.
+        │                                 'a @(ν'a. [∀. 'a]) -> 'a @(ν'a. [∀. 'a])]))
+        │                         list`
+    |}];
+  do_test
+    {|
+      external h : int -> (forall 'a. 'a -> 'a);;
+      external k : 'a. 'a -> 'a list -> 'a;;
+      external lst : ['a. int -> 'a -> 'a] list;;
+      let _ = k (fun x -> h x) lst;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:37:32
+     37 │        let _ = k (fun x -> h x) lst;;
+        │                                 ^^^ `(((int) @(ν'a. [∀. 'a]))
+        │                                       @(ν'b.
+        │                                           [∀'a.
+        │                                              'b ->
+        │                                              ('a @(ν'a. [∀. 'a]) ->
+        │                                               'a @(ν'a. [∀. 'a]))
+        │                                              @(ν'a. [∀. 'a])]))
+        │                                      list`
+        │                                       is not equal to
+        │                                     `('a -> 'b) list`
+    |}];
+  do_test
+    {|
+      external r : (forall 'a. 'a -> (forall 'b. 'b -> 'b)) -> int;;
+      let _ = r (fun x -> fun y -> y);;
+    |};
+  [%expect {| Well typed :) |}]
 ;;

--- a/lib/parser/parser.mly
+++ b/lib/parser/parser.mly
@@ -119,7 +119,7 @@ arrow_type:
       { type_ }
   | type1 = arrow_arg_type
     ; "->"
-    ; type2 = arrow_type
+    ; type2 = arrow_ret_type
       { Type.arrow ~range:(range_of_lex $loc) type1 type2 }
 
 
@@ -128,9 +128,19 @@ arrow_arg_type:
       { Type.Function_param.mono ~range:(range_of_lex $loc) type_ }
   | "("
     ; "forall" 
-    ; scheme = core_scheme
+    ; scheme = poly_core_scheme
     ; ")"
       { Type.Function_param.poly ~range:(range_of_lex $loc) scheme }
+
+
+arrow_ret_type:
+    type_ = arrow_type 
+      { Type.Function_return.mono ~range:(range_of_lex $loc) type_ }
+  | "("
+    ; "forall" 
+    ; scheme = poly_core_scheme
+    ; ")"
+      { Type.Function_return.poly ~range:(range_of_lex $loc) scheme }
 
 tuple_type:
     type_ = atom_type
@@ -269,9 +279,10 @@ expression:
       { Expression.if_ ~range:(range_of_lex $loc) cond ~then_ ~else_ }
   | "fun"
     ; pats = nonempty_list(function_param)
+    ; rtype = option(function_ret_type_annot)
     ; "->"
     ; exp = seq_expression
-      { Expression.fun_ ~range:(range_of_lex $loc) pats exp }
+      { Expression.fun_ ~range:(range_of_lex $loc) pats ?return_type:rtype exp }
   | "exists"
     ; "("
     ; "type"
@@ -428,6 +439,20 @@ function_param:
           pat 
           scheme
       }
+
+function_ret_type_annot:
+    ":"
+    ; rtype = atom_arrow_ret_type
+      { rtype }
+
+atom_arrow_ret_type:
+    type_ = atom_type
+      { Type.Function_return.mono ~range:(range_of_lex $loc) type_ }
+  | "("
+    ; "forall"
+    ; scheme = poly_core_scheme
+    ; ")"
+      { Type.Function_return.poly ~range:(range_of_lex $loc) scheme }
 
 pattern:
     pat = construct_pattern

--- a/lib/parser/test/test_parser.ml
+++ b/lib/parser/test/test_parser.ml
@@ -451,16 +451,24 @@ let%expect_test "core_type : function" =
                  (Reader
                   ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))
              ((it
-               (Type_constr ()
-                ((it int)
+               (Return_mono_type
+                ((it
+                  (Type_constr ()
+                   ((it int)
+                    (range
+                     ((start 9) (stop 12)
+                      (source
+                       (Reader
+                        ((id 0) (name (expect_test.ml)) (length 28)
+                         (unsafe_get <fun>)))))))))
                  (range
-                  ((start 9) (stop 12)
+                  ((start 8) (stop 12)
                    (source
                     (Reader
                      ((id 0) (name (expect_test.ml)) (length 28)
                       (unsafe_get <fun>)))))))))
               (range
-               ((start 8) (stop 12)
+               ((start 9) (stop 12)
                 (source
                  (Reader
                   ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))))
@@ -475,38 +483,55 @@ let%expect_test "core_type : function" =
            (Reader
             ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))
        ((it
-         (Type_arrow
+         (Return_mono_type
           ((it
-            (Param_mono_type
+            (Type_arrow
              ((it
-               (Type_constr ()
-                ((it int)
+               (Param_mono_type
+                ((it
+                  (Type_constr ()
+                   ((it int)
+                    (range
+                     ((start 17) (stop 20)
+                      (source
+                       (Reader
+                        ((id 0) (name (expect_test.ml)) (length 28)
+                         (unsafe_get <fun>)))))))))
                  (range
-                  ((start 17) (stop 20)
+                  ((start 16) (stop 20)
                    (source
                     (Reader
                      ((id 0) (name (expect_test.ml)) (length 28)
                       (unsafe_get <fun>)))))))))
               (range
-               ((start 16) (stop 20)
+               ((start 17) (stop 20)
                 (source
                  (Reader
-                  ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))))
-           (range
-            ((start 17) (stop 20)
-             (source
-              (Reader
-               ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))
-          ((it
-            (Type_constr ()
-             ((it int)
+                  ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))
+             ((it
+               (Return_mono_type
+                ((it
+                  (Type_constr ()
+                   ((it int)
+                    (range
+                     ((start 24) (stop 27)
+                      (source
+                       (Reader
+                        ((id 0) (name (expect_test.ml)) (length 28)
+                         (unsafe_get <fun>)))))))))
+                 (range
+                  ((start 23) (stop 27)
+                   (source
+                    (Reader
+                     ((id 0) (name (expect_test.ml)) (length 28)
+                      (unsafe_get <fun>)))))))))
               (range
                ((start 24) (stop 27)
                 (source
                  (Reader
                   ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))))
            (range
-            ((start 23) (stop 27)
+            ((start 17) (stop 27)
              (source
               (Reader
                ((id 0) (name (expect_test.ml)) (length 28) (unsafe_get <fun>)))))))))
@@ -694,6 +719,7 @@ let%expect_test "fun : identity" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 12) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_var
           ((it x)
@@ -765,6 +791,7 @@ let%expect_test "fun : fst" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 17) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_var
           ((it x)
@@ -904,6 +931,7 @@ let%expect_test "fun : map" =
                       (Reader
                        ((id 0) (name (expect_test.ml)) (length 146)
                         (unsafe_get <fun>))))))))
+                 ()
                  ((it
                    (Exp_match
                     ((it
@@ -1214,6 +1242,7 @@ let%expect_test "annotation : exists" =
               (source
                (Reader
                 ((id 0) (name (expect_test.ml)) (length 62) (unsafe_get <fun>))))))))
+          ()
           ((it
             (Exp_annot
              ((it
@@ -1325,6 +1354,7 @@ let%expect_test "annotation : forall" =
               (source
                (Reader
                 ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>))))))))
+          ()
           ((it
             (Exp_annot
              ((it
@@ -1466,6 +1496,7 @@ let%expect_test "let : fact" =
                       (Reader
                        ((id 0) (name (expect_test.ml)) (length 97)
                         (unsafe_get <fun>))))))))
+                 ()
                  ((it
                    (Exp_if_then_else
                     ((it
@@ -1845,6 +1876,7 @@ let%expect_test "function - uncurry" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 23) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_app
           ((it
@@ -1931,6 +1963,7 @@ let%expect_test "pattern : constant" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 23) (unsafe_get <fun>))))))))
+       ()
        ((it (Exp_const Const_unit))
         (range
          ((start 16) (stop 18)
@@ -1968,6 +2001,7 @@ let%expect_test "pattern : wildcard" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 23) (unsafe_get <fun>))))))))
+       ()
        ((it (Exp_const Const_unit))
         (range
          ((start 16) (stop 18)
@@ -2051,6 +2085,7 @@ let%expect_test "pattern : constructor" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 34) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_var
           ((it x)
@@ -2132,6 +2167,7 @@ let%expect_test "pattern : tuple" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 33) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_var
           ((it x)
@@ -2207,6 +2243,7 @@ let%expect_test "pattern : annotation" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 29) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_var
           ((it x)
@@ -2319,6 +2356,7 @@ let%expect_test "pattern : as" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 46) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_var
           ((it y)
@@ -3092,6 +3130,7 @@ let%expect_test "eval example" =
                     (Reader
                      ((id 0) (name (expect_test.ml)) (length 806)
                       (unsafe_get <fun>))))))))
+               ()
                ((it
                  (Exp_match
                   ((it
@@ -3409,6 +3448,7 @@ let%expect_test "eval example" =
                        (Reader
                         ((id 0) (name (expect_test.ml)) (length 806)
                          (unsafe_get <fun>))))))))
+                  ()
                   ((it
                     (Exp_match
                      ((it
@@ -3802,6 +3842,7 @@ let%expect_test "eval example" =
                                             (Reader
                                              ((id 0) (name (expect_test.ml))
                                               (length 806) (unsafe_get <fun>))))))))
+                                       ()
                                        ((it
                                          (Exp_app
                                           ((it
@@ -4422,33 +4463,49 @@ let%expect_test "top level external definitions" =
                         ((id 0) (name (expect_test.ml)) (length 99)
                          (unsafe_get <fun>)))))))
                    ((it
-                     (Type_arrow
+                     (Return_mono_type
                       ((it
-                        (Param_mono_type
+                        (Type_arrow
                          ((it
-                           (Type_constr ()
-                            ((it int)
+                           (Param_mono_type
+                            ((it
+                              (Type_constr ()
+                               ((it int)
+                                (range
+                                 ((start 38) (stop 41)
+                                  (source
+                                   (Reader
+                                    ((id 0) (name (expect_test.ml)) (length 99)
+                                     (unsafe_get <fun>)))))))))
                              (range
-                              ((start 38) (stop 41)
+                              ((start 37) (stop 41)
                                (source
                                 (Reader
                                  ((id 0) (name (expect_test.ml)) (length 99)
                                   (unsafe_get <fun>)))))))))
                           (range
-                           ((start 37) (stop 41)
+                           ((start 38) (stop 41)
                             (source
                              (Reader
                               ((id 0) (name (expect_test.ml)) (length 99)
-                               (unsafe_get <fun>)))))))))
-                       (range
-                        ((start 38) (stop 41)
-                         (source
-                          (Reader
-                           ((id 0) (name (expect_test.ml)) (length 99)
-                            (unsafe_get <fun>)))))))
-                      ((it
-                        (Type_constr ()
-                         ((it bool)
+                               (unsafe_get <fun>)))))))
+                         ((it
+                           (Return_mono_type
+                            ((it
+                              (Type_constr ()
+                               ((it bool)
+                                (range
+                                 ((start 45) (stop 49)
+                                  (source
+                                   (Reader
+                                    ((id 0) (name (expect_test.ml)) (length 99)
+                                     (unsafe_get <fun>)))))))))
+                             (range
+                              ((start 44) (stop 49)
+                               (source
+                                (Reader
+                                 ((id 0) (name (expect_test.ml)) (length 99)
+                                  (unsafe_get <fun>)))))))))
                           (range
                            ((start 45) (stop 49)
                             (source
@@ -4456,7 +4513,7 @@ let%expect_test "top level external definitions" =
                               ((id 0) (name (expect_test.ml)) (length 99)
                                (unsafe_get <fun>)))))))))
                        (range
-                        ((start 44) (stop 49)
+                        ((start 38) (stop 49)
                          (source
                           (Reader
                            ((id 0) (name (expect_test.ml)) (length 99)
@@ -4534,16 +4591,24 @@ let%expect_test "top level external definitions" =
                         ((id 0) (name (expect_test.ml)) (length 99)
                          (unsafe_get <fun>)))))))
                    ((it
-                     (Type_constr ()
-                      ((it sexp)
+                     (Return_mono_type
+                      ((it
+                        (Type_constr ()
+                         ((it sexp)
+                          (range
+                           ((start 88) (stop 92)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 99)
+                               (unsafe_get <fun>)))))))))
                        (range
-                        ((start 88) (stop 92)
+                        ((start 87) (stop 92)
                          (source
                           (Reader
                            ((id 0) (name (expect_test.ml)) (length 99)
                             (unsafe_get <fun>)))))))))
                     (range
-                     ((start 87) (stop 92)
+                     ((start 88) (stop 92)
                       (source
                        (Reader
                         ((id 0) (name (expect_test.ml)) (length 99)
@@ -4688,8 +4753,16 @@ let%expect_test "polyparam - function" =
                         ((id 0) (name (expect_test.ml)) (length 59)
                          (unsafe_get <fun>)))))))
                    ((it
-                     (Type_var
-                      ((it a)
+                     (Return_mono_type
+                      ((it
+                        (Type_var
+                         ((it a)
+                          (range
+                           ((start 34) (stop 36)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 59)
+                               (unsafe_get <fun>)))))))))
                        (range
                         ((start 34) (stop 36)
                          (source
@@ -4718,6 +4791,7 @@ let%expect_test "polyparam - function" =
            (source
             (Reader
              ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>))))))))
+       ()
        ((it
          (Exp_sequence
           ((it

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -652,6 +652,25 @@ module Expression = struct
       ~else_:(fun () -> default_mono_poly ~id_source)
   ;;
 
+  let match_poly ~id_source ~range cvar ~poly_type =
+    match_
+      poly_type
+      ~closure:[ `Scheme cvar ]
+      ~with_:(function
+        | Poly { quantifiers; body } -> forall quantifiers @@ inst cvar body
+        | (Arrow _ | Constr _ | Tuple _) as matchee ->
+          let type_head =
+            match matchee with
+            | Arrow _ -> `Arrow
+            | Constr _ -> `Constr
+            | Tuple _ -> `Tuple
+            | _ -> assert false
+          in
+          ff (Omniml_error.polytype_mismatched_type ~range ~type_head))
+      ~error:(fun _ -> Omniml_error.ambiguous_polytype ~range)
+      ~else_:(fun () -> default_mono_poly ~id_source)
+  ;;
+
   let infer_pat ~env ~with_poly_params pat pat_type =
     let { Pattern.Fragment.var_bindings; exist_bindings }, cpat =
       Pattern.(infer_pat ~env ~with_poly_params pat pat_type |> With_fragment.run)
@@ -723,21 +742,22 @@ module Expression = struct
          ~in_:(in_ env)
   ;;
 
+  let bind_param ~env ~with_poly_params param type_ ~in_ =
+    match With_range.it param with
+    | Param_mono_val pat ->
+      if with_poly_params
+      then bind_unknown_poly_pat ~env ~with_poly_params pat type_ ~in_
+      else bind_mono_pat ~env ~with_poly_params pat type_ ~in_
+    | Param_poly_val { pat; scheme } ->
+      assert with_poly_params;
+      bind_known_poly_pat ~env ~with_poly_params pat scheme type_ ~in_
+  ;;
+
   let rec bind_params ~env ~with_poly_params params_and_types ~in_ =
     match params_and_types with
     | [] -> in_ env
     | (param, param_type) :: params_and_types ->
-      let infer_param : in_:_ -> _ =
-        match With_range.it param with
-        | Param_mono_val pat ->
-          if with_poly_params
-          then bind_unknown_poly_pat ~env ~with_poly_params pat param_type
-          else bind_mono_pat ~env ~with_poly_params pat param_type
-        | Param_poly_val { pat; scheme } ->
-          assert with_poly_params;
-          bind_known_poly_pat ~env ~with_poly_params pat scheme param_type
-      in
-      infer_param ~in_:(fun env ->
+      bind_param ~env ~with_poly_params param param_type ~in_:(fun env ->
         bind_params ~env ~with_poly_params params_and_types ~in_)
   ;;
 
@@ -756,75 +776,80 @@ module Expression = struct
        | Some var -> inst var (Type.var exp_type)
        | None -> Omniml_error.(raise @@ unbound_variable ~range:var.range var.it))
     | Exp_const const -> Type.(var exp_type =~ infer_constant const)
-    | Exp_fun (params, ret_type_annot, exp) ->
-      exists_many' ~id_source (List.length params)
-      @@ fun as1 ->
-      exists' ~id_source
-      @@ fun a2 ->
-      let params_and_types = List.zip_exn params as1 in
-      let c =
-        bind_params ~env ~with_poly_params params_and_types ~in_:(fun env ->
-          let exp =
-            if with_poly_params
-            then Ast_builder.Expression.poly ~range:exp.range exp ()
-            else exp
-          in
-          let annot_type =
-            Option.map ret_type_annot ~f:(fun ret_type_annot ->
-              let range = ret_type_annot.range in
-              match ret_type_annot.it with
-              | Return_mono_type type_ ->
-                if with_poly_params
-                then Ast_builder.Type.(poly ~range (scheme ~range type_))
-                else type_
-              | Return_poly_type scheme ->
-                assert with_poly_params;
-                Ast_builder.Type.poly ~range scheme)
-          in
-          let exp =
-            match annot_type with
-            | None -> exp
-            | Some annot -> Ast_builder.Expression.annot ~range:exp.range exp annot
-          in
-          infer_exp ~env ~with_poly_params exp a2)
+    | Exp_fun (params, ret_type_annot, exp_body) ->
+      let ret_type_annot =
+        Option.map
+          ret_type_annot
+          ~f:(Convert.core_ret_type_to_type ~env ~with_poly_params)
       in
-      (* a2 is boxed, due to the above elaboration. *)
-      let nparams = List.length as1 in
-      let _, arr_type =
-        List.fold_right
-          as1
-          ~init:(0, Type.var a2)
-          ~f:(fun a1 (arrow_size, arr) ->
-            let arr = Type.(var a1 @-> arr) in
-            let arrow_size = arrow_size + 1 in
-            let arr =
-              if with_poly_params && arrow_size < nparams
-              then Type.(poly (Scheme.create arr))
-              else arr
-            in
-            arrow_size, arr)
+      let infer_arrow ~range ~env ~param ?expected_ret_type arr_type ~infer_body =
+        exists' ~id_source
+        @@ fun poly_param_type ->
+        exists' ~id_source
+        @@ fun poly_ret_type ->
+        (* Ensure [arr_type] is an arrow with param type [poly_param_type] 
+           and return type [poly_ret_type] *)
+        Type.(var arr_type =~ var poly_param_type @-> var poly_ret_type)
+        (* Check the expected ret type *)
+        &~ Option.value_map expected_ret_type ~default:tt ~f:(fun expected_ret_type ->
+          Type.(var poly_ret_type =~ expected_ret_type))
+        &~ bind_param ~env ~with_poly_params param poly_param_type ~in_:(fun env ->
+          (* Check that [exp] has a more general type than [poly_ret_type] *)
+          if with_poly_params
+          then
+            with_range ~range
+            @@ infer_principal ~env ~f:(fun body_type -> infer_body ~env body_type)
+            @@ fun cvar -> match_poly ~id_source ~range cvar ~poly_type:poly_ret_type
+          else infer_body ~env poly_ret_type)
       in
-      Type.(var exp_type =~ arr_type) &~ c
+      let rec infer_arrows ~env params arr_type =
+        match params with
+        | [] -> assert false
+        | [ param ] ->
+          infer_arrow
+            ~range:exp_body.range
+            ~env
+            ~param
+            ?expected_ret_type:ret_type_annot
+            arr_type
+            ~infer_body:(fun ~env exp_type ->
+              infer_exp ~env ~with_poly_params exp_body exp_type)
+        | param :: params ->
+          infer_arrow
+            ~range:exp.range
+            ~env
+            ~param
+            arr_type
+            ~infer_body:(fun ~env arr_type -> infer_arrows ~env params arr_type)
+      in
+      infer_arrows ~env params exp_type
     | Exp_app (exp1, exp2) ->
       exists' ~id_source
-      @@ fun a1 ->
+      @@ fun arr_type ->
       exists' ~id_source
-      @@ fun a2 ->
+      @@ fun poly_param_type ->
       exists' ~id_source
       @@ fun poly_ret_type ->
-      let c1 = infer_exp ~env ~with_poly_params exp1 a2 in
-      let c2 =
-        let exp2 =
-          if with_poly_params
-          then Ast_builder.Expression.poly ~range:exp2.range exp2 ()
-          else exp2
-        in
-        infer_exp ~env ~with_poly_params exp2 a1
+      (* Ensure that [exp1] has an arrow type w/ parameter type [poly_param_type] 
+         and return type [poly_ret_type] *)
+      let c1 =
+        infer_exp ~env ~with_poly_params exp1 arr_type
+        &~ with_range ~range:exp1.range
+           @@ Type.(var arr_type =~ var poly_param_type @-> var poly_ret_type)
       in
-      Type.(var a2 =~ var a1 @-> var poly_ret_type)
-      &~ c1
+      (* Check that [exp2] has a more general type than [poly_param_type] *)
+      let c2 =
+        if with_poly_params
+        then
+          infer_exp_principal ~env ~with_poly_params exp2
+          @@ fun cvar ->
+          match_poly ~id_source ~range:exp2.range cvar ~poly_type:poly_param_type
+        else infer_exp ~env ~with_poly_params exp2 poly_param_type
+      in
+      c1
       &~ c2
       &~
+      (* Check that [exp_type] is an instance of [poly_ret_type] *)
       if with_poly_params
       then
         match_inst
@@ -955,23 +980,7 @@ module Expression = struct
       (match scheme_annot with
        | None ->
          infer_exp_principal ~env ~with_poly_params exp
-         @@ fun cvar ->
-         match_
-           exp_type
-           ~closure:[ `Scheme cvar ]
-           ~with_:(function
-             | Poly { quantifiers; body } -> forall quantifiers @@ inst cvar body
-             | (Arrow _ | Constr _ | Tuple _) as matchee ->
-               let type_head =
-                 match matchee with
-                 | Arrow _ -> `Arrow
-                 | Constr _ -> `Constr
-                 | Tuple _ -> `Tuple
-                 | _ -> assert false
-               in
-               ff (Omniml_error.polytype_mismatched_type ~range:exp.range ~type_head))
-           ~error:(fun _ -> Omniml_error.ambiguous_polytype ~range:exp.range)
-           ~else_:(fun () -> default_mono_poly ~id_source)
+         @@ fun cvar -> match_poly ~id_source ~range:exp.range cvar ~poly_type:exp_type
        | Some core_scheme ->
          let quantifiers, type_ =
            Convert.core_scheme ~env ~with_poly_params core_scheme
@@ -1009,16 +1018,17 @@ module Expression = struct
     inst_label ~env ~label_name ~label_type
     @@ fun arg_type -> infer_exp ~env ~with_poly_params arg_exp arg_type
 
-  and infer_exp_principal ~env ~with_poly_params exp k =
+  and infer_principal ~env ~f k =
     let id_source = Env.id_source env in
     let cvar = Var.create ~id_source () in
-    let exp_type = Type.Var.create ~id_source () in
+    let type_ = Type.Var.create ~id_source () in
     let_
-      (poly_binding
-         ([ Flexible, exp_type ]
-          @. infer_exp ~env ~with_poly_params exp exp_type
-          @=> [ cvar @: Type.var exp_type ]))
+      (poly_binding ([ Flexible, type_ ] @. f type_ @=> [ cvar @: Type.var type_ ]))
       ~in_:(k cvar)
+
+  and infer_exp_principal ~env ~with_poly_params exp k =
+    with_range ~range:exp.range
+    @@ infer_principal ~env ~f:(infer_exp ~env ~with_poly_params exp) k
 
   and infer_cases ~env ~with_poly_params cases ~lhs_type ~rhs_type =
     let cs =

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -45,7 +45,7 @@ module Convert = struct
     | Type_var v -> Type_var v.it
     | Type_arrow (param_type, ret_type) ->
       let type_expr1 = core_param_type_to_type_expr ~env ~with_poly_params param_type
-      and type_expr2 = self ret_type in
+      and type_expr2 = core_ret_type_to_type_expr ~env ~with_poly_params ret_type in
       Type_arrow (type_expr1, type_expr2)
     | Type_tuple types ->
       let type_exprs = List.map types ~f:self in
@@ -82,6 +82,20 @@ module Convert = struct
       assert with_poly_params;
       let scheme = core_scheme_to_type_scheme_expr ~env ~with_poly_params scheme in
       Type_poly scheme
+
+  and core_ret_type_to_type_expr ~env ~with_poly_params (type_ : Ast.return_type)
+    : Adt.type_expr
+    =
+    match type_.it with
+    | Return_mono_type mono_type ->
+      let type_expr = core_type_to_type_expr ~env ~with_poly_params mono_type in
+      if with_poly_params
+      then Type_poly { scheme_quantifiers = []; scheme_body = type_expr }
+      else type_expr
+    | Return_poly_type scheme ->
+      assert with_poly_params;
+      let scheme = core_scheme_to_type_scheme_expr ~env ~with_poly_params scheme in
+      Type_poly scheme
   ;;
 
   let rec core_type_to_type ~env ~with_poly_params (type_ : Ast.core_type) : Type.t =
@@ -93,7 +107,7 @@ module Convert = struct
        | None -> Omniml_error.(raise @@ unbound_type_variable ~range:v.range v.it))
     | Type_arrow (param_type, ret_type) ->
       let type1 = core_param_type_to_type ~env ~with_poly_params param_type
-      and type2 = self ret_type in
+      and type2 = core_ret_type_to_type ~env ~with_poly_params ret_type in
       Type.(type1 @-> type2)
     | Type_tuple types ->
       let types = types |> List.map ~f:self in
@@ -129,6 +143,17 @@ module Convert = struct
       then Type.poly (Type.Scheme.create ~quantifiers:[] type_)
       else type_
     | Param_poly_type scheme ->
+      let scheme = core_scheme_to_type_scheme ~env ~with_poly_params scheme in
+      Type.poly scheme
+
+  and core_ret_type_to_type ~env ~with_poly_params (ret_type : Ast.return_type) : Type.t =
+    match ret_type.it with
+    | Return_mono_type mono_type ->
+      let type_ = core_type_to_type ~env ~with_poly_params mono_type in
+      if with_poly_params
+      then Type.poly (Type.Scheme.create ~quantifiers:[] type_)
+      else type_
+    | Return_poly_type scheme ->
       let scheme = core_scheme_to_type_scheme ~env ~with_poly_params scheme in
       Type.poly scheme
   ;;
@@ -731,7 +756,7 @@ module Expression = struct
        | Some var -> inst var (Type.var exp_type)
        | None -> Omniml_error.(raise @@ unbound_variable ~range:var.range var.it))
     | Exp_const const -> Type.(var exp_type =~ infer_constant const)
-    | Exp_fun (params, exp) ->
+    | Exp_fun (params, ret_type_annot, exp) ->
       exists_many' ~id_source (List.length params)
       @@ fun as1 ->
       exists' ~id_source
@@ -739,10 +764,45 @@ module Expression = struct
       let params_and_types = List.zip_exn params as1 in
       let c =
         bind_params ~env ~with_poly_params params_and_types ~in_:(fun env ->
+          let exp =
+            if with_poly_params
+            then Ast_builder.Expression.poly ~range:exp.range exp ()
+            else exp
+          in
+          let annot_type =
+            Option.map ret_type_annot ~f:(fun ret_type_annot ->
+              let range = ret_type_annot.range in
+              match ret_type_annot.it with
+              | Return_mono_type type_ ->
+                if with_poly_params
+                then Ast_builder.Type.(poly ~range (scheme ~range type_))
+                else type_
+              | Return_poly_type scheme ->
+                assert with_poly_params;
+                Ast_builder.Type.poly ~range scheme)
+          in
+          let exp =
+            match annot_type with
+            | None -> exp
+            | Some annot -> Ast_builder.Expression.annot ~range:exp.range exp annot
+          in
           infer_exp ~env ~with_poly_params exp a2)
       in
-      let arr_type =
-        List.fold_right as1 ~init:(Type.var a2) ~f:(fun a1 arr -> Type.(var a1 @-> arr))
+      (* a2 is boxed, due to the above elaboration. *)
+      let nparams = List.length as1 in
+      let _, arr_type =
+        List.fold_right
+          as1
+          ~init:(0, Type.var a2)
+          ~f:(fun a1 (arrow_size, arr) ->
+            let arr = Type.(var a1 @-> arr) in
+            let arrow_size = arrow_size + 1 in
+            let arr =
+              if with_poly_params && arrow_size < nparams
+              then Type.(poly (Scheme.create arr))
+              else arr
+            in
+            arrow_size, arr)
       in
       Type.(var exp_type =~ arr_type) &~ c
     | Exp_app (exp1, exp2) ->
@@ -750,6 +810,8 @@ module Expression = struct
       @@ fun a1 ->
       exists' ~id_source
       @@ fun a2 ->
+      exists' ~id_source
+      @@ fun poly_ret_type ->
       let c1 = infer_exp ~env ~with_poly_params exp1 a2 in
       let c2 =
         let exp2 =
@@ -759,7 +821,18 @@ module Expression = struct
         in
         infer_exp ~env ~with_poly_params exp2 a1
       in
-      Type.(var a2 =~ var a1 @-> var exp_type) &~ c1 &~ c2
+      Type.(var a2 =~ var a1 @-> var poly_ret_type)
+      &~ c1
+      &~ c2
+      &~
+      if with_poly_params
+      then
+        match_inst
+          ~id_source
+          ~range:exp.range
+          ~poly_type:poly_ret_type
+          ~mono_type:exp_type
+      else Type.(var poly_ret_type =~ var exp_type)
     | Exp_let (value_binding, exp) ->
       infer_value_binding ~env ~with_poly_params value_binding
       @@ fun env -> infer_exp ~env ~with_poly_params exp exp_type

--- a/lib/type_checker/predef.ml
+++ b/lib/type_checker/predef.ml
@@ -16,20 +16,40 @@ module Env = struct
     if with_poly_params then Type.poly (Type.Scheme.create type_) else type_
   ;;
 
-  let bool_bop ~with_poly_params =
-    Type.(arg_type ~with_poly_params bool @-> arg_type ~with_poly_params bool @-> bool)
+  let ret_type ~with_poly_params type_ =
+    if with_poly_params then Type.poly (Type.Scheme.create type_) else type_
   ;;
 
-  let bool_uop ~with_poly_params = Type.(arg_type ~with_poly_params bool @-> bool)
+  let bool_bop ~with_poly_params =
+    Type.(
+      arg_type ~with_poly_params bool
+      @-> ret_type
+            ~with_poly_params
+            (arg_type ~with_poly_params bool @-> ret_type ~with_poly_params bool))
+  ;;
+
+  let bool_uop ~with_poly_params =
+    Type.(arg_type ~with_poly_params bool @-> ret_type ~with_poly_params bool)
+  ;;
 
   let int_bop ~with_poly_params =
-    Type.(arg_type ~with_poly_params int @-> arg_type ~with_poly_params int @-> int)
+    Type.(
+      arg_type ~with_poly_params int
+      @-> ret_type
+            ~with_poly_params
+            (arg_type ~with_poly_params int @-> ret_type ~with_poly_params int))
   ;;
 
-  let int_uop ~with_poly_params = Type.(arg_type ~with_poly_params int @-> int)
+  let int_uop ~with_poly_params =
+    Type.(arg_type ~with_poly_params int @-> ret_type ~with_poly_params int)
+  ;;
 
   let int_comparator ~with_poly_params =
-    Type.(arg_type ~with_poly_params int @-> arg_type ~with_poly_params int @-> bool)
+    Type.(
+      arg_type ~with_poly_params int
+      @-> ret_type
+            ~with_poly_params
+            (arg_type ~with_poly_params int @-> ret_type ~with_poly_params bool))
   ;;
 
   let type_def name arity ident =


### PR DESCRIPTION
This makes polyparams more symmetric by permitting arbitrary-rank types. 
As a result, we obtain impredicative higher-rank polymorphism.

Translation function into boxed polymorphism:
```
[[ fun x -> e ]] = fun x -> let x = @[ x ] in [ [[ e ]] ] 
[[ e1 e2 ]] = @[ [[ e1 ]] [ [[ e2 ]] ] ]
```

Polymorphism is never inferred, it just propagates from an annotation. 

Like polyparams (and QuickLook), arrows are invariant to the ML subsumption relation.