### PR TITLE
feat: add support for static overloading

### DIFF
--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -32,6 +32,7 @@ type pattern = pattern_desc With_range.t
 and pattern_desc =
   | Pat_any
   | Pat_var of Var_name.With_range.t
+  | Pat_over of Over_path.t
   | Pat_alias of pattern * Var_name.With_range.t
   | Pat_const of constant
   | Pat_tuple of pattern list
@@ -54,6 +55,7 @@ type expression = expression_desc With_range.t
 
 and expression_desc =
   | Exp_var of Var_name.With_range.t
+  | Exp_over of Over_path.t
   | Exp_const of constant
   | Exp_fun of function_param list * expression
   | Exp_app of expression * expression

--- a/lib/ast/ast_builder.ml
+++ b/lib/ast/ast_builder.ml
@@ -14,6 +14,10 @@ module type S = sig
   val var_name : (string -> Var_name.With_range.t) with_range_fn
   val constr_name : (string -> Constructor_name.With_range.t) with_range_fn
   val label_name : (string -> Label_name.With_range.t) with_range_fn
+  val over_name : (string -> Over_name.With_range.t) with_range_fn
+
+  val over_path
+    : (Over_name.With_range.t -> Var_name.With_range.t -> Over_path.t) with_range_fn
 
   module Type : sig
     module Function_param : sig
@@ -35,6 +39,7 @@ module type S = sig
   module Pattern : sig
     val any : pattern with_range_fn
     val var : (Var_name.With_range.t -> pattern) with_range_fn
+    val over : (Over_path.t -> pattern) with_range_fn
     val alias : (pattern -> as_:Var_name.With_range.t -> pattern) with_range_fn
     val const : (constant -> pattern) with_range_fn
     val tuple : (pattern list -> pattern) with_range_fn
@@ -53,6 +58,7 @@ module type S = sig
     end
 
     val var : (Var_name.With_range.t -> expression) with_range_fn
+    val over : (Over_path.t -> expression) with_range_fn
     val const : (constant -> expression) with_range_fn
     val fun_ : (function_param list -> expression -> expression) with_range_fn
     val app : (expression -> expression -> expression) with_range_fn
@@ -117,6 +123,11 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
   let constr_name ~range name = With_range.create ~range @@ Constructor_name.create name
   let type_name ~range name = With_range.create ~range @@ Type_name.create name
   let label_name ~range name = With_range.create ~range @@ Label_name.create name
+  let over_name ~range name = With_range.create ~range @@ Over_name.create name
+
+  let over_path ~range qualifier var =
+    With_range.create ~range @@ { Over_path.qualifier; var }
+  ;;
 
   module Type = struct
     module Function_param = struct
@@ -142,6 +153,7 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
   module Pattern = struct
     let any ~range = With_range.create ~range Pat_any
     let var ~range var_name = With_range.create ~range @@ Pat_var var_name
+    let over ~range over_path = With_range.create ~range @@ Pat_over over_path
     let alias ~range pat ~as_ = With_range.create ~range @@ Pat_alias (pat, as_)
     let const ~range const = With_range.create ~range @@ Pat_const const
     let tuple ~range pats = With_range.create ~range @@ Pat_tuple pats
@@ -164,6 +176,7 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
     end
 
     let var ~range var_name = With_range.create ~range @@ Exp_var var_name
+    let over ~range over_path = With_range.create ~range @@ Exp_over over_path
     let const ~range const = With_range.create ~range @@ Exp_const const
     let fun_ ~range pats exp = With_range.create ~range @@ Exp_fun (pats, exp)
     let app ~range exp1 exp2 = With_range.create ~range @@ Exp_app (exp1, exp2)
@@ -238,6 +251,8 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
   let constr_name = constr_name ~range:R.v
   let type_name = type_name ~range:R.v
   let label_name = label_name ~range:R.v
+  let over_name = over_name ~range:R.v
+  let over_path = over_path ~range:R.v
 
   module Type = struct
     module Function_param = struct
@@ -256,6 +271,7 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
   module Pattern = struct
     let any = Pattern.any ~range:R.v
     let var = Pattern.var ~range:R.v
+    let over = Pattern.over ~range:R.v
     let alias = Pattern.alias ~range:R.v
     let const = Pattern.const ~range:R.v
     let tuple = Pattern.tuple ~range:R.v
@@ -271,6 +287,7 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
     end
 
     let var = Expression.var ~range:R.v
+    let over = Expression.over ~range:R.v
     let const = Expression.const ~range:R.v
     let fun_ = Expression.fun_ ~range:R.v
     let app = Expression.app ~range:R.v

--- a/lib/ast/ast_types.ml
+++ b/lib/ast/ast_types.ml
@@ -44,8 +44,25 @@ module Ident = struct
   end
 end
 
+module Over_name = Ident.Make ()
 module Var_name = Ident.Make ()
 module Type_var_name = Ident.Make ()
 module Type_name = Ident.Make ()
 module Constructor_name = Ident.Make ()
 module Label_name = Ident.Make ()
+
+module Over_path = struct
+  type t = desc With_range.t
+
+  and desc =
+    { var : Var_name.With_range.t
+    ; qualifier : Over_name.With_range.t
+    }
+  [@@deriving sexp_of]
+
+  let pp ppf (t : t) =
+    Fmt.pf ppf "%a/%a" Over_name.pp t.it.qualifier.it Var_name.pp t.it.var.it
+  ;;
+
+  let to_string = Fmt.to_to_string pp
+end

--- a/lib/ast/dune
+++ b/lib/ast/dune
@@ -1,6 +1,6 @@
 (library
  (name omniml_ast)
  (public_name omniml.ast)
- (libraries core grace)
+ (libraries core grace fmt)
  (preprocess
   (pps ppx_jane)))

--- a/lib/constraint_solver/constraint.ml
+++ b/lib/constraint_solver/constraint.ml
@@ -43,6 +43,7 @@ type t =
   | Forall of Type.Var.t list * t
   | Let of let_binding * t
   | Instance of Var.t * Type.t
+  | Over_instance of Var.t list * Type.t
   | Match of
       { matchee : Type.Var.t
       ; closure : Closure.t
@@ -90,6 +91,7 @@ let ( @. ) t1 t2 = t1, t2
 let poly_binding (type_vars, (in_, bindings)) = { type_vars; in_; bindings }
 let let_ binding ~in_ = Let (binding, in_)
 let inst x type_ = Instance (x, type_)
+let over xs type_ = Over_instance (xs, type_)
 
 let match_ matchee ~closure ~with_ ~else_ ~error =
   Match { matchee; closure = Closure.of_list closure; case = with_; else_; error }

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -984,7 +984,7 @@ module Suspended_match = struct
   type t =
     { matchee : Type.t
     ; closure : closure
-    ; case : curr_region:Region.t -> shape:Principal_shape.t -> args:Type.t list -> unit
+    ; case : shape:Principal_shape.t -> args:Type.t list -> unit
     ; else_ : unit -> Principal_shape.t
     ; error : Constraint.Match_error.t -> Omniml_error.t
     }
@@ -1055,54 +1055,59 @@ module Suspended_match = struct
     in
     let add_handler ~shape_args svar =
       [%log.global.debug "Adding handler" (svar : Principal_shape.Var.t)];
-      Principal_shape.Var.add_handler
-        svar
-        { run =
-            (fun shape ->
-              let args = get_or_alloc_matchee_args () in
-              (* Remove guard from closure *)
-              closure_remove_guard ~state ~shape_args closure;
-              (* Solve case *)
-              case ~curr_region ~shape ~args;
-              [%log.global.debug
-                "Generalization tree after solving case"
-                  (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
-        ; default =
-            (fun () ->
-              [%log.global.debug
-                "Default handler triggered" (svar : Principal_shape.Var.t)];
-              let default_shape = else_ () in
-              [%log.global.debug "Default shape" (default_shape : Principal_shape.t)];
-              (try
-                 Principal_shape.Var.fill_exn
-                   ~state:state.shape_var_state
-                   svar
-                   default_shape
-               with
-               | Principal_shape.Var.Not_empty ->
-                 let actual = Principal_shape.Var.peek_exn svar in
-                 let report =
-                   error (Inconsistent_default { actual; expected = default_shape })
-                 in
-                 raise (Inconsistent_defaults report));
-              [%log.global.debug
-                "Generalization tree running default handler"
-                  (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
-        ; error = (fun () -> error Cannot_default)
-        };
+      let handler =
+        Principal_shape.Var.add_handler
+          svar
+          { run =
+              (fun shape ->
+                let args = get_or_alloc_matchee_args () in
+                (* Remove guard from closure *)
+                closure_remove_guard ~state ~shape_args closure;
+                (* Solve case *)
+                case ~shape ~args;
+                [%log.global.debug
+                  "Generalization tree after solving case"
+                    (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
+          ; default =
+              (fun () ->
+                [%log.global.debug
+                  "Default handler triggered" (svar : Principal_shape.Var.t)];
+                let default_shape = else_ () in
+                [%log.global.debug "Default shape" (default_shape : Principal_shape.t)];
+                (try
+                   Principal_shape.Var.fill_exn
+                     ~state:state.shape_var_state
+                     svar
+                     default_shape
+                 with
+                 | Principal_shape.Var.Not_empty ->
+                   let actual = Principal_shape.Var.peek_exn svar in
+                   let report =
+                     error (Inconsistent_default { actual; expected = default_shape })
+                   in
+                   raise (Inconsistent_defaults report));
+                [%log.global.debug
+                  "Generalization tree running default handler"
+                    (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
+          ; cancel = (fun () -> closure_remove_guard ~state ~shape_args closure)
+          ; error = (fun () -> error Cannot_default)
+          }
+      in
       (* Add guard to closure *)
-      closure_add_guard ~state ~shape_args closure
+      closure_add_guard ~state ~shape_args closure;
+      handler
     in
     match Type.inner matchee with
     | Var ->
       let shape_var = create_shape_var ~state ~curr_region () in
       let shape_args = create_var ~state ~curr_region () in
-      add_handler ~shape_args shape_var;
+      let handler = add_handler ~shape_args shape_var in
       unify
         ~state
         ~curr_region
         matchee
-        (create_shape_app ~state ~curr_region shape_args shape_var)
+        (create_shape_app ~state ~curr_region shape_args shape_var);
+      handler
     | Structure (Structure (Shape_app { args = shape_args; shape_var })) ->
       add_handler ~shape_args shape_var
     | Structure (Structure (Shape_args _)) ->
@@ -1114,6 +1119,7 @@ module Suspended_match = struct
     | Structure Rigid_var -> raise (Cannot_match_on_rigid (error Matchee_is_rigid))
     | Structure (Structure (Structure { args; shape })) ->
       (* Optimisation: Immediately solve the case *)
-      case ~curr_region ~shape ~args
+      case ~shape ~args;
+      None
   ;;
 end

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -222,6 +222,8 @@ module Constraint : sig
       bound to [x]. The variable [x] must be bound earlier by {!let_}. *)
   val inst : Var.t -> Type.t -> t
 
+  val over : Var.t list -> Type.t -> t
+
   module Match_error : sig
     type t =
       | Cannot_default

--- a/lib/constraint_solver/principal_shape.ml
+++ b/lib/constraint_solver/principal_shape.ml
@@ -301,6 +301,7 @@ module Var = struct
     type nonrec t =
       { run : t -> unit
       ; default : unit -> unit
+      ; cancel : unit -> unit
       ; error : unit -> Omniml_error.t
       }
     [@@deriving sexp_of]
@@ -310,25 +311,28 @@ module Var = struct
 
     let schedule_all ts shape =
       let scheduler = Scheduler.t () in
-      List.iter ts ~f:(fun t ->
+      Doubly_linked.iter ts ~f:(fun t ->
         let job = fun () -> t.run shape in
-        Scheduler.enqueue scheduler job)
+        Scheduler.enqueue scheduler job);
+      Doubly_linked.clear ts
     ;;
 
     let schedule_default_all ts =
       [%log.global.debug "Scheduling defaults"];
       let scheduler = Scheduler.t () in
-      List.iter ts ~f:(fun t ->
+      Doubly_linked.iter ts ~f:(fun t ->
         [%log.global.debug "Scheduling default"];
         Scheduler.enqueue scheduler t.default)
     ;;
 
-    let errors ts = List.map ts ~f:(fun t -> t.error ())
+    let errors ts =
+      Doubly_linked.fold_right ts ~init:[] ~f:(fun t acc -> t.error () :: acc)
+    ;;
   end
 
   module S = struct
     type desc =
-      | Empty of Handler.t list
+      | Empty of Handler.t Doubly_linked.t
       | Full of t
     [@@deriving sexp_of]
 
@@ -346,7 +350,9 @@ module Var = struct
 
     let merge_desc ~ctx:_ ~create:_ ~unify:_ ~type1:_ ~type2:_ t1 t2 =
       match t1, t2 with
-      | Empty hs1, Empty hs2 -> Empty (hs1 @ hs2)
+      | Empty hs1, Empty hs2 ->
+        Doubly_linked.transfer ~src:hs2 ~dst:hs1;
+        Empty hs1
       | Full s1, Full s2 -> if equal s1 s2 then Full s1 else raise Cannot_merge
       | Empty hs, Full s | Full s, Empty hs ->
         Handler.schedule_all hs s;
@@ -367,7 +373,7 @@ module Var = struct
       { id = Identifier.create id_source
       ; region
       ; guards = Guard_set.empty
-      ; desc = Empty []
+      ; desc = Empty (Doubly_linked.create ())
       }
     ;;
   end
@@ -392,10 +398,28 @@ module Var = struct
     | Full _ -> false
   ;;
 
+  module Registered_handler = struct
+    type t =
+      { wait_list : Handler.t Doubly_linked.t
+      ; handler : Handler.t Doubly_linked.Elt.t
+      }
+
+    let cancel_if_pending t =
+      if not (Doubly_linked.is_empty t.wait_list)
+      then (
+        (Doubly_linked.Elt.value t.handler).cancel ();
+        Doubly_linked.remove t.wait_list t.handler)
+    ;;
+  end
+
   let add_handler t handler =
     match desc t with
-    | Full s -> Handler.schedule handler s
-    | Empty handlers -> set_desc t (Empty (handler :: handlers))
+    | Full s ->
+      Handler.schedule handler s;
+      None
+    | Empty handlers ->
+      let handler = Doubly_linked.insert_first handlers handler in
+      Some { Registered_handler.wait_list = handlers; handler }
   ;;
 
   exception Empty

--- a/lib/constraint_solver/principal_shape.mli
+++ b/lib/constraint_solver/principal_shape.mli
@@ -34,11 +34,20 @@ module Var : sig
       { run : shape -> unit
         (** [run shape] runs the handler, where [shape] is the filled shape.  *)
       ; default : unit -> unit (** [default ()] is used to fill the variable (or fail). *)
+      ; cancel : unit -> unit (** [cancel ()] is used to cancel the handler. *)
       ; error : unit -> Omniml_error.t
         (** [error ()] is used to generate an error if the shape 
             variable cannot be defaulted. *)
       }
     [@@deriving sexp_of]
+  end
+
+  module Registered_handler : sig
+    type t
+
+    (** [cancel_if_pending t] removes the handler from its associated waitlist if 
+        it has not yet been scheduled. *)
+    val cancel_if_pending : t -> unit
   end
 
   (** A write-once cell containing a principal shape. *)
@@ -68,7 +77,7 @@ module Var : sig
   (** [add_handler t h] adds a handler to the shape var that is scheduled 
       once the variable is filled. If the shape is already filled, then 
       the handler is scheduled immediately. *)
-  val add_handler : t -> Handler.t -> unit
+  val add_handler : t -> Handler.t -> Registered_handler.t option
 
   exception Empty
 

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -227,10 +227,12 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     [%log.global.debug
       "Closure of suspended match" (gclosure : G.Suspended_match.closure)];
     (* Register match for the shape *)
-    let case ~curr_region ~shape ~args =
+    let case ~shape ~args =
       [%log.global.debug "Entered match handler" (shape : Principal_shape.t)];
       (* Enter region and construct env *)
-      let env = Env.of_gclosure gclosure ~closure ~curr_region ~range:env.range in
+      let env =
+        Env.of_gclosure gclosure ~closure ~curr_region:env.curr_region ~range:env.range
+      in
       [%log.global.debug "Handler env" (env : Env.t)];
       [%log.global.debug "Handler state" (state : State.t)];
       (* Solve *)
@@ -248,10 +250,13 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
       else_ ()
     in
     [%log.global.debug "Suspending match..."];
-    G.Suspended_match.match_or_yield
-      ~state
-      ~curr_region:env.curr_region
-      { matchee = gmatchee; closure = gclosure; case; else_; error }
+    let _ =
+      G.Suspended_match.match_or_yield
+        ~state
+        ~curr_region:env.curr_region
+        { matchee = gmatchee; closure = gclosure; case; else_; error }
+    in
+    ()
   | With_range (t, range) -> solve ~state ~env:(Env.with_range env ~range) t
 
 and solve_let_binding ~state ~env { type_vars; in_; bindings } =

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -170,6 +170,116 @@ let match_type
   | Sh_poly poly_shape -> env, Poly poly_shape.scheme
 ;;
 
+module Over_switch = struct
+  type t = { mutable remaining_overs : over Constraint.Var.Map.t }
+
+  and over =
+    { mutable over_handlers : Principal_shape.Var.Registered_handler.t list
+    ; over_root : G.Type.t
+    }
+
+  let create initial_overs =
+    { remaining_overs =
+        initial_overs
+        |> List.map ~f:(fun (over_var, over_root) ->
+          over_var, { over_root; over_handlers = [] })
+        |> Constraint.Var.Map.of_alist_exn
+    }
+  ;;
+
+  let remove_over t over =
+    Map.find t.remaining_overs over
+    |> Option.iter ~f:(fun { over_handlers; over_root = _ } ->
+      List.iter over_handlers ~f:Principal_shape.Var.Registered_handler.cancel_if_pending;
+      t.remaining_overs <- Map.remove t.remaining_overs over)
+  ;;
+
+  let ambiguous t = Map.length t.remaining_overs > 1
+
+  let unify_if_unique ~state ~env t expected_type =
+    if ambiguous t
+    then ()
+    else (
+      match Map.to_alist t.remaining_overs with
+      | [ (_over_var, over) ] -> unify ~state ~env over.over_root expected_type
+      | _ -> assert false)
+  ;;
+
+  let over_match ~(state : State.t) ~(env : Env.t) t ~over matchee ~closure ~with_ =
+    let range = Option.value_exn ~here:[%here] env.range in
+    match Map.find t.remaining_overs over with
+    | None ->
+      (* overload was already removed, no need to generate any subsequent constraints *)
+      ()
+    | Some over ->
+      let handler =
+        G.Suspended_match.match_or_yield
+          ~state
+          ~curr_region:env.curr_region
+          { matchee
+          ; closure = { variables = over.over_root :: closure; schemes = [] }
+          ; case = with_
+          ; else_ = (fun () -> Omniml_error.(raise @@ ambiguous_overloading ~range))
+          ; error = (fun _ -> Omniml_error.ambiguous_overloading ~range)
+          }
+      in
+      (match handler with
+       | Some handler -> over.over_handlers <- handler :: over.over_handlers
+       | None -> ())
+  ;;
+
+  let rec filter_over
+            ~(state : State.t)
+            ~(env : Env.t)
+            t
+            ~expected_type
+            ~over
+            over_type_p
+            expected_type_p
+    =
+    over_match
+      ~state
+      ~env
+      t
+      ~over
+      expected_type_p
+      ~closure:[ expected_type; over_type_p ]
+      ~with_:(fun ~shape:expected_type_p_shape ~args:expected_type_p_args ->
+        over_match
+          ~state
+          ~env
+          t
+          ~over
+          over_type_p
+          ~closure:([ expected_type ] @ expected_type_p_args)
+          ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
+            if Principal_shape.equal expected_type_p_shape over_type_p_shape
+            then
+              List.iter2_exn
+                expected_type_p_args
+                over_type_p_args
+                ~f:(fun expected_type_p_arg over_type_p_arg ->
+                  filter_over
+                    ~state
+                    ~env
+                    t
+                    ~expected_type
+                    ~over
+                    over_type_p_arg
+                    expected_type_p_arg)
+            else (
+              remove_over t over;
+              unify_if_unique ~state ~env t expected_type)))
+  ;;
+
+  let match_ ~state ~env t ~expected_type =
+    Map.iteri
+      t.remaining_overs
+      ~f:(fun ~key:over ~data:{ over_root; over_handlers = _ } ->
+        filter_over ~state ~env t ~expected_type ~over over_root expected_type)
+  ;;
+end
+
 let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
   fun ~state ~env cst ->
   [%log.global.debug
@@ -210,6 +320,18 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     let actual_gtype = G.instantiate ~state ~curr_region:env.curr_region var_gscheme in
     [%log.global.debug "Scheme instance" (actual_gtype : G.Type.t)];
     unify ~state ~env actual_gtype expected_gtype
+  | Over_instance (vars, expected_type) ->
+    [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
+    let expected_gtype = gtype_of_type ~state ~env expected_type in
+    [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
+    let overs =
+      vars
+      |> List.map ~f:(fun over_var ->
+        let var_gscheme = Env.find_var env over_var in
+        over_var, G.instantiate ~state ~curr_region:env.curr_region var_gscheme)
+    in
+    let switch = Over_switch.create overs in
+    Over_switch.match_ ~state ~env switch ~expected_type:expected_gtype
   | Exists (type_var, cst) ->
     [%log.global.debug "Binding unification for type_var" (type_var : Type.Var.t)];
     let env = exists ~state ~env ~type_var in
@@ -250,7 +372,7 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
       else_ ()
     in
     [%log.global.debug "Suspending match..."];
-    let _ =
+    let _ : Principal_shape.Var.Registered_handler.t option =
       G.Suspended_match.match_or_yield
         ~state
         ~curr_region:env.curr_region

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -175,49 +175,67 @@ module Over_switch = struct
 
   and over =
     { mutable over_handlers : Principal_shape.Var.Registered_handler.t list
-    ; over_root : G.Type.t
+    ; over_scheme : G.Scheme.t
     }
 
   let create initial_overs =
     { remaining_overs =
         initial_overs
-        |> List.map ~f:(fun (over_var, over_root) ->
-          over_var, { over_root; over_handlers = [] })
+        |> List.map ~f:(fun (over_var, over_scheme) ->
+          over_var, { over_scheme; over_handlers = [] })
         |> Constraint.Var.Map.of_alist_exn
     }
   ;;
 
   let remove_over t over =
     Map.find t.remaining_overs over
-    |> Option.iter ~f:(fun { over_handlers; over_root = _ } ->
+    |> Option.iter ~f:(fun { over_handlers; over_scheme = _ } ->
       List.iter over_handlers ~f:Principal_shape.Var.Registered_handler.cancel_if_pending;
       t.remaining_overs <- Map.remove t.remaining_overs over)
   ;;
 
   let ambiguous t = Map.length t.remaining_overs > 1
 
-  let unify_if_unique ~state ~env t expected_type =
+  let unify_if_unique ~(state : State.t) ~(env : Env.t) t expected_type =
     if ambiguous t
     then ()
     else (
       match Map.to_alist t.remaining_overs with
-      | [ (_over_var, over) ] -> unify ~state ~env over.over_root expected_type
+      | [ (_over_var, over) ] ->
+        let actual_gtype =
+          G.instantiate ~state ~curr_region:env.curr_region over.over_scheme
+        in
+        unify ~state ~env actual_gtype expected_type
       | _ -> assert false)
   ;;
 
-  let over_match ~(state : State.t) ~(env : Env.t) t ~over matchee ~closure ~with_ =
+  let over_match
+        ~(state : State.t)
+        ~(env : Env.t)
+        ~curr_region
+        t
+        ~over
+        matchee
+        ~closure
+        ~with_
+    =
     let range = Option.value_exn ~here:[%here] env.range in
     match Map.find t.remaining_overs over with
     | None ->
       (* overload was already removed, no need to generate any subsequent constraints *)
       ()
     | Some over ->
+      let curr_region =
+        match curr_region with
+        | `Env -> env.curr_region
+        | `Over -> over.over_scheme.region
+      in
       let handler =
         G.Suspended_match.match_or_yield
           ~state
-          ~curr_region:env.curr_region
+          ~curr_region
           { matchee
-          ; closure = { variables = over.over_root :: closure; schemes = [] }
+          ; closure = { variables = closure; schemes = [ over.over_scheme ] }
           ; case = with_
           ; else_ = (fun () -> Omniml_error.(raise @@ ambiguous_overloading ~range))
           ; error = (fun _ -> Omniml_error.ambiguous_overloading ~range)
@@ -240,43 +258,53 @@ module Over_switch = struct
     over_match
       ~state
       ~env
+      ~curr_region:`Env
       t
       ~over
       expected_type_p
-      ~closure:[ expected_type; over_type_p ]
+      ~closure:[ expected_type ]
       ~with_:(fun ~shape:expected_type_p_shape ~args:expected_type_p_args ->
-        over_match
-          ~state
-          ~env
-          t
-          ~over
-          over_type_p
-          ~closure:([ expected_type ] @ expected_type_p_args)
-          ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
-            if Principal_shape.equal expected_type_p_shape over_type_p_shape
-            then
-              List.iter2_exn
-                expected_type_p_args
-                over_type_p_args
-                ~f:(fun expected_type_p_arg over_type_p_arg ->
-                  filter_over
-                    ~state
-                    ~env
-                    t
-                    ~expected_type
-                    ~over
-                    over_type_p_arg
-                    expected_type_p_arg)
-            else (
-              remove_over t over;
-              unify_if_unique ~state ~env t expected_type)))
+        if
+          G.Type.is_generic over_type_p
+          &&
+          match G.Type.inner over_type_p with
+          | Var -> true
+          | _ -> false
+        then ()
+        else
+          over_match
+            ~state
+            ~env
+            ~curr_region:`Over
+            t
+            ~over
+            over_type_p
+            ~closure:([ expected_type ] @ expected_type_p_args)
+            ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
+              if Principal_shape.equal expected_type_p_shape over_type_p_shape
+              then
+                List.iter2_exn
+                  expected_type_p_args
+                  over_type_p_args
+                  ~f:(fun expected_type_p_arg over_type_p_arg ->
+                    filter_over
+                      ~state
+                      ~env
+                      t
+                      ~expected_type
+                      ~over
+                      over_type_p_arg
+                      expected_type_p_arg)
+              else (
+                remove_over t over;
+                unify_if_unique ~state ~env t expected_type)))
   ;;
 
   let match_ ~state ~env t ~expected_type =
     Map.iteri
       t.remaining_overs
-      ~f:(fun ~key:over ~data:{ over_root; over_handlers = _ } ->
-        filter_over ~state ~env t ~expected_type ~over over_root expected_type)
+      ~f:(fun ~key:over ~data:{ over_scheme; over_handlers = _ } ->
+        filter_over ~state ~env t ~expected_type ~over over_scheme.root expected_type)
   ;;
 end
 
@@ -324,12 +352,7 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
     let expected_gtype = gtype_of_type ~state ~env expected_type in
     [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
-    let overs =
-      vars
-      |> List.map ~f:(fun over_var ->
-        let var_gscheme = Env.find_var env over_var in
-        over_var, G.instantiate ~state ~curr_region:env.curr_region var_gscheme)
-    in
+    let overs = List.map vars ~f:(fun over_var -> over_var, Env.find_var env over_var) in
     let switch = Over_switch.create overs in
     Over_switch.match_ ~state ~env switch ~expected_type:expected_gtype
   | Exists (type_var, cst) ->

--- a/lib/error/omniml_error.ml
+++ b/lib/error/omniml_error.ml
@@ -22,6 +22,7 @@ module Code = struct
     | Projection_out_of_bounds
     | Ambiguous_tuple
     | Ambiguous_polytype
+    | Ambiguous_overloading
     | Unknown
   [@@deriving sexp]
 
@@ -42,6 +43,7 @@ module Code = struct
     | Projection_out_of_bounds -> "E014"
     | Ambiguous_tuple -> "E015"
     | Ambiguous_polytype -> "E016"
+    | Ambiguous_overloading -> "E017"
     | Unknown -> "E???"
   ;;
 end
@@ -135,6 +137,17 @@ let unbound_variable ~range (var_name : Var_name.t) : t =
        "cannot find value %a in this scope"
        pp_quoted_s
        (var_name :> string)
+;;
+
+let unbound_over_path (over_path : Over_path.t) : t =
+  singleton
+  @@ Diagnostic.createf
+       ~labels:[ not_found_in_this_scope_label ~range:over_path.range ]
+       ~code:Code.Unbound_variable
+       Error
+       "cannot find value %a in this scope"
+       (pp_quoted Over_path.pp)
+       over_path
 ;;
 
 let unbound_type ~range (type_name : Type_name.t) : t =
@@ -336,6 +349,17 @@ let ambiguous_constructor ~range =
        ~code:Code.Ambiguous_constructor
        Error
        "ambiguous constructor"
+;;
+
+let ambiguous_overloading ~range =
+  let open Diagnostic in
+  singleton
+  @@ Diagnostic.createf
+       ~labels:[ empty_primary_label ~range ]
+       ~notes:[ Message.createf "hint: add a type annotation" ]
+       ~code:Code.Ambiguous_overloading
+       Error
+       "ambiguous overloading"
 ;;
 
 let rigid_variable_escape ~range =

--- a/lib/error/omniml_error.mli
+++ b/lib/error/omniml_error.mli
@@ -35,6 +35,7 @@ val unterminated_comment : range:Range.t -> t
 val unknown_start_of_token : range:Range.t -> char -> t
 val syntax_error : range:Range.t -> t
 val unbound_variable : range:Range.t -> Var_name.t -> t
+val unbound_over_path : Over_path.t -> t
 val unbound_type : range:Range.t -> Type_name.t -> t
 val unbound_type_variable : range:Range.t -> Type_var_name.t -> t
 val unbound_constructor : range:Range.t -> Constructor_name.t -> t
@@ -62,6 +63,7 @@ val constructor_arity_mismatch
 val mismatched_type : range:Range.t -> pp_type:'a Fmt.t -> 'a -> 'a -> t
 
 val ambiguous_constructor : range:Range.t -> t
+val ambiguous_overloading : range:Range.t -> t
 
 val disambiguation_mismatched_type
   :  range:Range.t

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -48,6 +48,8 @@ let include_list =
       | Nil
       | Cons of 'a * 'a list
     ;;
+
+    external map_list : 'a 'b. ('a -> 'b) -> 'a list -> 'b list;;
   |}
 ;;
 
@@ -1924,8 +1926,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:25:27
-     25 │        let xignore = poly1 [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:27:27
+     27 │        let xignore = poly1 [(fun x -> x + 1)];;
         │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                 is not equal to
         │                                               `'a -> 'a`
@@ -1956,8 +1958,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E012]: generic type variable escapes its scope
-        ┌─ expect_test.ml:28:35
-     28 │        let escape = fun f -> poly1 [(fun x -> f x; x)];;
+        ┌─ expect_test.ml:30:35
+     30 │        let escape = fun f -> poly1 [(fun x -> f x; x)];;
         │                                    ^^^^^^^^^^^^^^^^^^^
     |}];
   do_test
@@ -1981,8 +1983,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:33:27
-     33 │        let xignore = poly2 [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:35:27
+     35 │        let xignore = poly2 [(fun x -> x + 1)];;
         │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                 is not equal to
         │                                               `'a -> 'a`
@@ -2011,8 +2013,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:41:27
-     41 │        let xignore = poly3 [(fun x -> x + 1)] [8];;
+        ┌─ expect_test.ml:43:27
+     43 │        let xignore = poly3 [(fun x -> x + 1)] [8];;
         │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                 is not equal to
         │                                               `'a -> 'a`
@@ -2039,8 +2041,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:47:34
-     47 │        let xignore = poly4 [true] [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:49:34
+     49 │        let xignore = poly4 [true] [(fun x -> x + 1)];;
         │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                        is not equal to
         │                                                      `'a -> 'a`
@@ -2067,8 +2069,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:53:34
-     53 │        let xignore = poly5 [true] [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:55:34
+     55 │        let xignore = poly5 [true] [(fun x -> x + 1)];;
         │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                        is not equal to
         │                                                      `'a -> 'a`
@@ -2098,8 +2100,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:62:34
-     62 │        let xignore = poly6 [true] [(fun x -> x + 1)] [8];;
+        ┌─ expect_test.ml:64:34
+     64 │        let xignore = poly6 [true] [(fun x -> x + 1)] [8];;
         │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                        is not equal to
         │                                                      `'a -> 'a`
@@ -2120,8 +2122,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:67:33
-     67 │        let xignore = needs_magic [(fun x -> x)];;
+        ┌─ expect_test.ml:69:33
+     69 │        let xignore = needs_magic [(fun x -> x)];;
         │                                  ^^^^^^^^^^^^^^ `'a -> 'a`
         │                                                   is not equal to
         │                                                 `'b -> 'c`
@@ -2247,8 +2249,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:24:28
-     24 │        let xignore = poly1 (fun x -> x + 1);;
+        ┌─ expect_test.ml:26:28
+     26 │        let xignore = poly1 (fun x -> x + 1);;
         │                             ^^^^^^^^^^^^^^ `'a -> int`
         │                                              is not equal to
         │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2284,8 +2286,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E012]: generic type variable escapes its scope
-        ┌─ expect_test.ml:26:36
-     26 │        let escape = fun f -> poly1 (fun x -> f x; x);;
+        ┌─ expect_test.ml:28:36
+     28 │        let escape = fun f -> poly1 (fun x -> f x; x);;
         │                                     ^^^^^^^^^^^^^^^
     |}];
   do_test
@@ -2308,8 +2310,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:30:28
-     30 │        let xignore = poly2 (fun x -> x + 1);;
+        ┌─ expect_test.ml:32:28
+     32 │        let xignore = poly2 (fun x -> x + 1);;
         │                             ^^^^^^^^^^^^^^ `'a -> int`
         │                                              is not equal to
         │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2336,8 +2338,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:36:28
-     36 │        let xignore = poly3 (fun x -> x + 1) 8;;
+        ┌─ expect_test.ml:38:28
+     38 │        let xignore = poly3 (fun x -> x + 1) 8;;
         │                             ^^^^^^^^^^^^^^ `'a -> int`
         │                                              is not equal to
         │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2362,8 +2364,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:40:33
-     40 │        let xignore = poly4 true (fun x -> x + 1);;
+        ┌─ expect_test.ml:42:33
+     42 │        let xignore = poly4 true (fun x -> x + 1);;
         │                                  ^^^^^^^^^^^^^^ `'a -> int`
         │                                                   is not equal to
         │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2388,8 +2390,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:44:33
-     44 │        let xignore = poly5 true (fun x -> x + 1);;
+        ┌─ expect_test.ml:46:33
+     46 │        let xignore = poly5 true (fun x -> x + 1);;
         │                                  ^^^^^^^^^^^^^^ `'a -> int`
         │                                                   is not equal to
         │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2416,8 +2418,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:50:33
-     50 │        let xignore = poly6 true (fun x -> x + 1) 8;;
+        ┌─ expect_test.ml:52:33
+     52 │        let xignore = poly6 true (fun x -> x + 1) 8;;
         │                                  ^^^^^^^^^^^^^^ `'a -> int`
         │                                                   is not equal to
         │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2458,42 +2460,44 @@ let%expect_test "" =
      17 │ │        | Cons of 'a * 'a list
      18 │ │      ;;
      19 │ │
-     20 │ │        let poly1 = fun (forall id : 'a. 'a -> 'a) ->
-     21 │ │          (id 1, id true)
-     22 │ │        ;;
-     23 │ │
-     24 │ │        let id = fun x -> x;;
+     20 │ │      external map_list : 'a 'b. ('a -> 'b) -> 'a list -> 'b list;;
+     21 │ │
+     22 │ │        let poly1 = fun (forall id : 'a. 'a -> 'a) ->
+     23 │ │          (id 1, id true)
+     24 │ │        ;;
      25 │ │
-     26 │ │        let poly2 = fun (forall id : 'a. 'a -> 'a) ->
-     27 │ │          ((id 1, id true) : int * bool)
-     28 │ │        ;;
-     29 │ │
-     30 │ │        let poly3 =
-     31 │ │          forall (type 'b) ->
-     32 │ │            fun (forall id : 'a. 'a -> 'a) (x : 'b) ->
-     33 │ │              ((id x, id (Some x)) : 'b * 'b option)
-     34 │ │        ;;
-     35 │ │
-     36 │ │        let poly4 = fix (fun poly4 p (forall id : 'a. 'a -> 'a) ->
-     37 │ │          if p then poly4 false id else (id 4, id true))
-     38 │ │        ;;
-     39 │ │
-     40 │ │        let poly5 = fix (fun poly5 (p : bool) (forall id : 'a. 'a -> 'a) ->
-     41 │ │          ((if p then poly5 false id else (id 5, id true)) : int * bool))
-     42 │ │        ;;
-     43 │ │
-     44 │ │        let poly6 = forall (type 'b) ->
-     45 │ │          fix (fun poly6 ->
-     46 │ │            fun (p : bool) (forall id : 'a. 'a -> 'a) (x : 'b) ->
-     47 │ │              ((if p then poly6 false id x else (id x, id (Some x))) : 'b * 'b option))
-     48 │ │        ;;
-     49 │ │
-     50 │ │        let needs_magic = fun (forall magic : 'a 'b. 'a -> 'b) ->
-     51 │ │          (magic 5 : bool)
-     52 │ │        ;;
-     53 │ │
-     54 │ │        let xignore = needs_magic (fun x -> x);;
+     26 │ │        let id = fun x -> x;;
+     27 │ │
+     28 │ │        let poly2 = fun (forall id : 'a. 'a -> 'a) ->
+     29 │ │          ((id 1, id true) : int * bool)
+     30 │ │        ;;
+     31 │ │
+     32 │ │        let poly3 =
+     33 │ │          forall (type 'b) ->
+     34 │ │            fun (forall id : 'a. 'a -> 'a) (x : 'b) ->
+     35 │ │              ((id x, id (Some x)) : 'b * 'b option)
+     36 │ │        ;;
+     37 │ │
+     38 │ │        let poly4 = fix (fun poly4 p (forall id : 'a. 'a -> 'a) ->
+     39 │ │          if p then poly4 false id else (id 4, id true))
+     40 │ │        ;;
+     41 │ │
+     42 │ │        let poly5 = fix (fun poly5 (p : bool) (forall id : 'a. 'a -> 'a) ->
+     43 │ │          ((if p then poly5 false id else (id 5, id true)) : int * bool))
+     44 │ │        ;;
+     45 │ │
+     46 │ │        let poly6 = forall (type 'b) ->
+     47 │ │          fix (fun poly6 ->
+     48 │ │            fun (p : bool) (forall id : 'a. 'a -> 'a) (x : 'b) ->
+     49 │ │              ((if p then poly6 false id x else (id x, id (Some x))) : 'b * 'b option))
+     50 │ │        ;;
+     51 │ │
+     52 │ │        let needs_magic = fun (forall magic : 'a 'b. 'a -> 'b) ->
+     53 │ │          (magic 5 : bool)
+     54 │ │        ;;
      55 │ │
+     56 │ │        let xignore = needs_magic (fun x -> x);;
+     57 │ │
         │ ╰─────^ `'a`
                  is not equal to
                `'b`
@@ -3213,6 +3217,438 @@ let%expect_test "" =
         ┌─ expect_test.ml:2:26
       2 │        let _ = fun f -> f f;;
         │                           ^
+        = hint: add a type annotation
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    {|
+      let x = 1;;
+      let y = true;;
+      let z = ();; 
+
+
+      let f = 
+        let q?a = x in
+        let r?a = y in
+        let s?a = z in
+        (a : int)
+      ;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let include_array =
+  {|
+    type 'a array;; 
+
+    external map_array : 'a 'b. ('a -> 'b) -> 'a array -> 'b array;;
+  |}
+;;
+
+let include_float =
+  {|
+    type float;; 
+
+    external add_float : float -> float -> float;;
+    external sub_float : float -> float -> float;;
+    external div_float : float -> float -> float;;
+    external mul_float : float -> float -> float;;
+
+    external compare_float : float -> float -> int;;
+
+    external float_of_int : int -> float;;
+
+    let zero_float = float_of_int 0;;
+    let neg_float = fun n -> sub_float zero_float n;;
+  |}
+;;
+
+let include_string =
+  {|
+    type string;;
+
+    external empty_string : string;;
+    external concat_string : string -> string -> string;;
+    external length_string : string -> int;;
+  |}
+;;
+
+let%expect_test "" =
+  let test =
+    Incremental_test.create
+      ~initial:
+        (include_float
+         ^ include_array
+         ^ include_list
+         ^ include_string
+         ^ {|
+             let int?add = fun x y -> x + y;; 
+             let float?add = add_float;;
+
+             let int?mul = fun x y -> x * y;;
+             let float?mul = mul_float;;
+
+             let int?compare = fun x y -> 
+               if x < y then -1
+               else if x > y then 1
+               else 0
+             ;; 
+             let float?compare = compare_float;;
+
+             let int?zero = 0;; 
+             let float?zero = zero_float;;
+
+             let int?one = 1;; 
+             let float?one = float_of_int 1;;
+
+             let int?two = 2;;
+             let float?two = float_of_int 2;;  
+
+             let int?three = 3;;
+             let float?three = float_of_int 3;;
+
+             let int?four = 4;;
+             let float?four = float_of_int 4;;
+
+             let int?fourty_two = 42;;
+             let float?fourty_two = float_of_int 42;;
+           |}
+        )
+      type_check_and_print
+  in
+  let do_test = Incremental_test.run test in
+  do_test
+    {|
+      let ex1 = fun (x : int) (y : int) -> add x y;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex1_bad = fun (x : int) (y : float) -> add x y;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:64:56
+     64 │        let ex1_bad = fun (x : int) (y : float) -> add x y;;
+        │                                                         ^ `float`
+        │                                                             is not equal to
+        │                                                           `int`
+    |}];
+  do_test
+    {|
+      let ex2 = fun (x : float) (y : float) -> add x y;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex3 = (zero : int);; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex4 = fun (x : int) -> add x zero;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex5 = fun (x : float) -> add x zero;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex6 = (add (add three four) (add one (add zero two)) : float);; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ambig = add;;
+    |};
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:64:19
+     64 │        let ambig = add;;
+        │                    ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:64:19
+     64 │        let ambig = add;;
+        │                    ^^^
+        = hint: add a type annotation
+    |}];
+  do_test
+    {|
+      let ex7 = 
+        (add (add three four) (add one (add zero two)) : int)
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex8 = fun (x : float) ->
+        if (compare x zero < 0) then 
+          add zero one 
+        else 
+          mul two x 
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet1 = fun (f : int -> int) (g : int -> int) (x : int) -> 
+        (add (f (add x fourty_two)) (g (add (mul two x) fourty_two)) : int)
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet1' = fun (f : float -> float) (g : float -> float) x -> 
+        add (f (add x fourty_two)) (g (add (mul two x) fourty_two))
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet1'' = fun (f : float -> float) g x -> 
+        add (f (add x fourty_two)) (g (add (mul two x) fourty_two))
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet2 = fun (f : int -> int) (g : int -> int) (x : int) -> 
+        let op = fun n -> add n fourty_two in 
+        (add (f (op x)) (g (op (mul two x))) : int)
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet2' = fun (f : float -> float) (g : float -> float) x -> 
+        let op = fun (n : float) -> add n fourty_two in 
+        add (f (op x)) (g (op (mul two x)))
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let list?map = map_list;;
+      let array?map = map_array;;
+
+      external d : float array;; 
+
+      let ex12 = 
+        map (fun x -> add (mul two x) one) d
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let example_success =
+        let x = (zero : float) in 
+        let y = add one x in 
+        let z = (two : float) in 
+        let t = (add (add three y) (add four z) : float) in 
+        add (add four z) one 
+      ;; 
+    |};
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_string
+    ^ {|
+      let add = fun x y -> x + y;; 
+      let concat = (concat_string : string -> string -> string);; 
+
+      let g0 = fun x -> 
+        let int?f = add in 
+        let string?f = concat in
+        f 1 x 
+      ;;
+
+      let g1 = fun (x : int) -> 
+        let int?f = add in 
+        let string?f = concat in
+        let fx = f x in 
+        let int?a = 1 in 
+        let string?a = empty_string in 
+        let z = (f : int -> int -> int) a in 
+        (fx, z)
+      ;; 
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_float
+    ^ {|
+      let int?zero = 0;; 
+      let float?zero = zero_float;; 
+      
+      type not_int_or_float;;
+      let foo = 
+        (zero : not_int_or_float)
+      ;; 
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:21:10
+     21 │          (zero : not_int_or_float)
+        │           ^^^^ `float`
+        │                  is not equal to
+        │                `not_int_or_float`
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_float
+    ^ include_string
+    ^ {|
+      let int?x = 1;;
+      let string?x = empty_string;;
+
+      let float?y = float_of_int 1;;
+      let int?y = 1;;
+
+      let int?add = fun x y -> x + y;;
+      let float?add = add_float;;
+
+      let z = add x y;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:21
+     31 │        let z = add x y;;
+        │                      ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:21
+     31 │        let z = add x y;;
+        │                      ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:19
+     31 │        let z = add x y;;
+        │                    ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:19
+     31 │        let z = add x y;;
+        │                    ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    {|
+      type t;; 
+      type s;;
+      type r;;
+
+      external foo : t -> s -> r;;
+      external bar : r -> r -> r;;
+    
+      let foo?foo_bar = foo;;
+      let bar?foo_bar = bar;;
+
+      let z = fun x -> foo_bar x x;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
         = hint: add a type annotation
     |}]
 ;;

--- a/lib/parser/lexer.mll
+++ b/lib/parser/lexer.mll
@@ -75,6 +75,8 @@ rule read  =
       { UNDERSCORE }
   | "|"
       { BAR }
+  | "?"
+      { QUESTION_MARK }
 
   (* comments *)
   | "(*"

--- a/lib/parser/omniml_parser.ml
+++ b/lib/parser/omniml_parser.ml
@@ -22,6 +22,7 @@ module Token = struct
     | RIGHT_BRACE -> Fmt.pf ppf "Right_brace"
     | RIGHT_ARROW -> Fmt.pf ppf "Right_arrow"
     | QUOTE -> Fmt.pf ppf "Quote"
+    | QUESTION_MARK -> Fmt.pf ppf "Question_mark"
     | PLUS -> Fmt.pf ppf "Plus"
     | OF -> Fmt.pf ppf "Of"
     | MINUS -> Fmt.pf ppf "Minus"

--- a/lib/parser/parser.mly
+++ b/lib/parser/parser.mly
@@ -232,6 +232,16 @@ core_scheme:
   id = "<ident>"
     { label_name ~range:(range_of_lex $loc) id }
 
+%inline over_name:
+  id = "<ident>"
+    { over_name ~range:(range_of_lex $loc) id }
+
+%inline over_path:
+  over_name = over_name
+  ; "?"
+  ; var_name = var_name
+    { over_path ~range:(range_of_lex $loc) over_name var_name }
+
 constant:
     int = "<int>"
       { Const_int int }
@@ -338,6 +348,8 @@ atom_expression:
       { Expression.const ~range:(range_of_lex $loc) const }
   | var_name = var_name
       { Expression.var ~range:(range_of_lex $loc) var_name }
+  | over_path = over_path
+      { Expression.over ~range:(range_of_lex $loc) over_path }
   | constr_name = constr_name
       { Expression.constr ~range:(range_of_lex $loc) constr_name None }
   | "("
@@ -451,6 +463,8 @@ atom_pattern:
       { Pattern.any ~range:(range_of_lex $loc) }
   | var_name = var_name
       { Pattern.var ~range:(range_of_lex $loc) var_name }
+  | over_path = over_path
+      { Pattern.over ~range:(range_of_lex $loc) over_path }
   | constr_name = constr_name
       { Pattern.constr ~range:(range_of_lex $loc) constr_name None }
   | "("

--- a/lib/parser/token.mly
+++ b/lib/parser/token.mly
@@ -21,6 +21,7 @@
 
 // operators
 %token RIGHT_ARROW "->"
+%token QUESTION_MARK "?"
 %token COLON ":"
 %token EQUAL "="
 %token DOT "."

--- a/lib/type_checker/env.ml
+++ b/lib/type_checker/env.ml
@@ -2,6 +2,21 @@ open! Import
 open Ast_types
 open Adt
 
+module Var_binding = struct
+  type t =
+    { var : Constraint.Var.t option
+    ; overloads : Constraint.Var.t Over_name.Map.t
+    }
+  [@@deriving sexp_of]
+
+  let empty = { var = None; overloads = Over_name.Map.empty }
+  let set t var = { t with var = Some var }
+
+  let set_overload t over_name cvar =
+    { t with overloads = Map.set t.overloads ~key:over_name ~data:cvar }
+  ;;
+end
+
 type t =
   { id_source : Identifier.source
     (** [id_source] is the identifier source for any constraint variables
@@ -16,7 +31,7 @@ type t =
   ; type_vars : Type.Var.t Type_var_name.Map.t
     (** [type_vars] is a renaming from (user-defined) type variables to
       constraint type variables (unique). *)
-  ; vars : Constraint.Var.t Var_name.Map.t
+  ; vars : Var_binding.t Var_name.Map.t
     (** [vars] is a renaming from (user-defined) variable names to
       constraint variables (unique). *)
   }
@@ -93,10 +108,33 @@ let rename_type_var t ~type_var ~in_ =
   in_ t ctype_var
 ;;
 
-let rename_var t ~var ~in_ =
-  let cvar =
-    Constraint.Var.create ~id_source:t.id_source ~name:(var : Var_name.t :> string) ()
+let rename_var_binding ~name ~set_binding t ~var ~in_ =
+  let cvar = Constraint.Var.create ~id_source:t.id_source ~name () in
+  let t =
+    { t with
+      vars =
+        Map.update t.vars var ~f:(fun binding ->
+          let binding = Option.value binding ~default:Var_binding.empty in
+          set_binding binding cvar)
+    }
   in
-  let t = { t with vars = Map.set t.vars ~key:var ~data:cvar } in
   in_ t cvar
+;;
+
+let rename_var t ~var ~in_ =
+  rename_var_binding
+    ~name:(var : Var_name.t :> string)
+    ~set_binding:Var_binding.set
+    t
+    ~var
+    ~in_
+;;
+
+let rename_over_path t ~over_path:(over_name, var) ~in_ =
+  rename_var_binding
+    ~name:(Fmt.str "%a?%a" Over_name.pp over_name Var_name.pp var)
+    ~set_binding:(fun binding cvar -> Var_binding.set_overload binding over_name cvar)
+    t
+    ~var
+    ~in_
 ;;

--- a/lib/type_checker/env.mli
+++ b/lib/type_checker/env.mli
@@ -46,11 +46,27 @@ val find_label : t -> Label_name.t -> label_definition list
     empty list is returned. *)
 val find_type_def : t -> Type_name.t -> type_definition list
 
+module Var_binding : sig
+  type t =
+    { var : Constraint.Var.t option
+    ; overloads : Constraint.Var.t Over_name.Map.t
+    }
+  [@@deriving sexp_of]
+end
+
 (** [find_var t var_name] returns the constraint variable that [var_name] is renamed to. *)
-val find_var : t -> Var_name.t -> Constraint.Var.t option
+val find_var : t -> Var_name.t -> Var_binding.t option
 
 (** [rename_var t ~var ~in_] renames the variable [var] to some fresh [cvar] in [in_]. *)
 val rename_var : t -> var:Var_name.t -> in_:(t -> Constraint.Var.t -> 'a) -> 'a
+
+(** [rename_over_path t ~over_path ~in_] renames the qualified variable [over_path] to some 
+    fresh [cvar] in [in_]. *)
+val rename_over_path
+  :  t
+  -> over_path:Over_name.t * Var_name.t
+  -> in_:(t -> Constraint.Var.t -> 'a)
+  -> 'a
 
 (** [find_type_var t type_var_name] returns the type variable that [type_var_name]
     is renamed to. *)

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -427,27 +427,55 @@ let inst_label ~(env : Env.t) ~(label_name : Label_name.With_range.t) ~label_typ
 
 module Pattern = struct
   module Fragment = struct
+    module Var_binding = struct
+      type t =
+        { var : Type.Var.t option
+        ; overloads : Type.Var.t Over_name.Map.t
+        }
+      [@@deriving sexp_of]
+
+      let empty = { var = None; overloads = Over_name.Map.empty }
+      let set t var = { t with var = Some var }
+
+      let set_overload t over_name var =
+        { t with overloads = Map.set t.overloads ~key:over_name ~data:var }
+      ;;
+
+      let merge t1 t2 =
+        { var = Option.merge t1.var t2.var ~f:(fun _ x -> x)
+        ; overloads =
+            Map.merge_skewed t1.overloads t2.overloads ~combine:(fun ~key:_ _ x -> x)
+        }
+      ;;
+    end
+
     type t =
-      { var_bindings : Type.Var.t Var_name.Map.t
+      { var_bindings : Var_binding.t Var_name.Map.t
       ; exist_bindings : Type.Var.t list
       }
     [@@deriving sexp_of]
 
     let empty = { var_bindings = Var_name.Map.empty; exist_bindings = [] }
 
-    let singleton var type_ =
-      { var_bindings = Var_name.Map.singleton var type_; exist_bindings = [] }
+    let singleton var binding =
+      { var_bindings = Var_name.Map.singleton var binding; exist_bindings = [] }
     ;;
 
-    let extend t ~var ~type_ =
-      { t with var_bindings = Map.set t.var_bindings ~key:var ~data:type_ }
+    let extend t ~var ~f =
+      { t with
+        var_bindings =
+          Map.update t.var_bindings var ~f:(fun binding ->
+            let binding = Option.value binding ~default:Var_binding.empty in
+            f binding)
+      }
     ;;
 
     let exists t type_var = { t with exist_bindings = type_var :: t.exist_bindings }
 
     let merge t1 t2 =
       { var_bindings =
-          Map.merge_skewed t1.var_bindings t2.var_bindings ~combine:(fun ~key:_ _ b -> b)
+          Map.merge_skewed t1.var_bindings t2.var_bindings ~combine:(fun ~key:_ b1 b2 ->
+            Var_binding.merge b1 b2)
       ; exist_bindings = t1.exist_bindings @ t2.exist_bindings
       }
     ;;
@@ -472,10 +500,7 @@ module Pattern = struct
     include Monad.Make (T)
 
     let perform_exists type_var = fun fragment -> Fragment.exists fragment type_var, ()
-
-    let perform_extend ~var ~type_ =
-      fun fragment -> Fragment.extend fragment ~var ~type_, ()
-    ;;
+    let perform_extend ~var ~f = fun fragment -> Fragment.extend fragment ~var ~f, ()
 
     let exists ~id_source f =
       let open Let_syntax in
@@ -515,11 +540,23 @@ module Pattern = struct
     match pat.it with
     | Pat_any -> return tt
     | Pat_var x ->
-      let%map () = perform_extend ~var:x.it ~type_:pat_type in
+      let%map () =
+        perform_extend ~var:x.it ~f:(fun binding ->
+          Fragment.Var_binding.set binding pat_type)
+      in
+      tt
+    | Pat_over over_path ->
+      let%map () =
+        perform_extend ~var:over_path.it.var.it ~f:(fun binding ->
+          Fragment.Var_binding.set_overload binding over_path.it.qualifier.it pat_type)
+      in
       tt
     | Pat_alias (pat, x) ->
       let%bind cpat = infer_pat ~env ~with_poly_params pat pat_type in
-      let%map () = perform_extend ~var:x.it ~type_:pat_type in
+      let%map () =
+        perform_extend ~var:x.it ~f:(fun binding ->
+          Fragment.Var_binding.set binding pat_type)
+      in
       cpat
     | Pat_const const -> return @@ Type.(var pat_type =~ infer_constant const)
     | Pat_tuple pats ->
@@ -634,10 +671,22 @@ module Expression = struct
     let env, bindings =
       var_bindings
       |> Map.to_alist
-      |> List.fold_map ~init:env ~f:(fun env (var, type_) ->
-        Env.rename_var env ~var ~in_:(fun env cvar -> env, cvar @: Type.var type_))
+      |> List.fold_map ~init:env ~f:(fun env (var, binding) ->
+        let in_ env =
+          binding.overloads
+          |> Map.to_alist
+          |> List.fold_map ~init:env ~f:(fun env (over_name, type_) ->
+            Env.rename_over_path env ~over_path:(over_name, var) ~in_:(fun env cvar ->
+              env, cvar @: Type.var type_))
+        in
+        match binding.var with
+        | None -> in_ env
+        | Some type_ ->
+          Env.rename_var env ~var ~in_:(fun env cvar ->
+            let env, bindings = in_ env in
+            env, (cvar @: Type.var type_) :: bindings))
     in
-    env, bindings, exist_bindings, cpat
+    env, List.concat bindings, exist_bindings, cpat
   ;;
 
   let bind_mono_pat ~env ~with_poly_params (pat : pattern) pat_type ~in_ =
@@ -716,6 +765,12 @@ module Expression = struct
         bind_params ~env ~with_poly_params params_and_types ~in_)
   ;;
 
+  let find_var_binding ~env (var : Var_name.With_range.t) =
+    match Env.find_var env var.it with
+    | Some binding -> binding
+    | None -> Omniml_error.(raise @@ unbound_variable ~range:var.range var.it)
+  ;;
+
   let rec infer_exp
             ~(env : Env.t)
             ~with_poly_params
@@ -727,9 +782,27 @@ module Expression = struct
     @@
     match exp.it with
     | Exp_var var ->
-      (match Env.find_var env var.it with
-       | Some var -> inst var (Type.var exp_type)
-       | None -> Omniml_error.(raise @@ unbound_variable ~range:var.range var.it))
+      let binding = find_var_binding ~env var in
+      (match binding.var with
+       | Some var -> inst var Type.(var exp_type)
+       | None ->
+         (if Map.is_empty binding.overloads
+          then
+            Omniml_error.(
+              raise
+              @@ bug_s
+                   ~here:[%here]
+                   [%message
+                     "Overloads is empty"
+                       (var : Var_name.With_range.t)
+                       (binding : Env.Var_binding.t)]));
+         let vars = Map.data binding.overloads in
+         over vars Type.(var exp_type))
+    | Exp_over over_path ->
+      let binding = find_var_binding ~env over_path.it.var in
+      (match Map.find binding.overloads over_path.it.qualifier.it with
+       | Some var -> inst var Type.(var exp_type)
+       | None -> Omniml_error.(raise @@ unbound_over_path over_path))
     | Exp_const const -> Type.(var exp_type =~ infer_constant const)
     | Exp_fun (params, exp) ->
       exists_many' ~id_source (List.length params)


### PR DESCRIPTION
This PR uses suspended match constraints to implement the static overloading a la Leijen. 

```ocaml
let int?add = fun x y -> x + y;; 
let bool?add = fun x y -> x || y;;

let succ = fun x -> add x 1;;
```

Syntax note: `m/x` would be ambiguous with `m / x` (division), so went for `m?x`