### PR TITLE
feat: add support for implicits

### DIFF
--- a/bin/omniml.ml
+++ b/bin/omniml.ml
@@ -42,6 +42,17 @@ module Params = struct
          Omniml_main.Options.Defaulting.arg_type)
       ~doc:"STRATEGY Defaulting strategy, disabled by default"
   ;;
+
+  let termination_check =
+    flag
+      "-termination-check"
+      (optional_with_default
+         Omniml_main.Options.Termination_check.default
+         Omniml_main.Options.Termination_check.arg_type)
+      ~doc:
+        "TERMINATION_CHECK Termination checker used during implicit resolution, \
+         `threshold:256` by default"
+  ;;
 end
 
 module Command = struct
@@ -90,6 +101,7 @@ module Command = struct
         +> Params.disable_stdlib
         +> Params.fpoly_params
         +> Params.defaulting
+        +> Params.termination_check
         +> Async_log.Global.set_level_via_param ())
       (fun filename
         dump_ast
@@ -97,6 +109,7 @@ module Command = struct
         without_stdlib
         with_poly_params
         defaulting
+        termination_check
         () ->
          open_with_lexbuf filename ~f:(fun lexbuf ->
            let source = `File filename in
@@ -108,6 +121,7 @@ module Command = struct
                ~with_stdlib:(not without_stdlib)
                ~with_poly_params
                ~defaulting
+               ~termination_check
                lexbuf
            in
            Async_log.Global.flushed ()))

--- a/examples/implicit_termination.ml
+++ b/examples/implicit_termination.ml
@@ -1,0 +1,14 @@
+type 'a list = 
+  | Nil
+  | Cons of 'a * 'a list
+;;
+
+let bad = 
+  fun? self -> exists (type 'a) -> 
+  let _ = (self : 'a list list) in (Nil : 'a list)
+;;
+
+let implicit bad;;
+
+let summon = fun? x -> x;;
+let _ = (summon : int list);;

--- a/examples/implicits.ml
+++ b/examples/implicits.ml
@@ -1,0 +1,28 @@
+type string;;
+
+external nil_string : string;;
+external cons_string : string -> string -> string;;
+external int_show : int -> string;;
+
+external fix : 'a 'b. (('a -> 'b) -> 'a -> 'b) -> 'a -> 'b;;
+
+
+type 'a list = 
+  | Nil
+  | Cons of 'a * 'a list
+;;
+
+let list_show = fun? showx -> 
+  fix (fun list_show xs -> 
+    match xs with (
+    | Nil -> nil_string
+    | Cons (x, xs) -> cons_string (showx x) (list_show xs)))
+;;
+
+
+let implicit int_show;;
+let implicit list_show;;
+
+let show = fun? showx -> exists (type 'a) -> fun (x : 'a) -> ((showx : 'a -> string) x);;
+
+let _ = show (Cons (1, Cons (2, Nil)));;

--- a/examples/scoped_overloading.ml
+++ b/examples/scoped_overloading.ml
@@ -1,0 +1,77 @@
+(** overloading *)
+
+(* predefine class incr *)
+type 'a incr = Incr of 'a ;;
+let val_incr = fun x -> Incr x;;
+let use_incr = fun x -> match x with (Incr v -> v);;
+let incr = fun? x -> use_incr x;;
+
+(* let incr!int x = x + 1 *)
+let incr_int = fun x -> x + 1;;
+let incr_int' = val_incr incr_int;;
+let implicit incr_int';;
+
+(* let incr!bool x = not x *)
+let incr_bool = fun x -> if x then false else true;;
+let incr_bool' = val_incr incr_bool;;
+let implicit incr_bool';;
+
+(* predefine class incr *)
+type 'a show = Show of 'a ;;
+let val_show = fun x -> Show x;;
+let use_show = fun x -> match x with (Show v -> v);;
+let show = fun? x -> use_show x;;
+
+(* String module *)
+type string;;
+external print_int : int -> string;;
+external print_bool : bool -> string;;
+external concat : string -> string -> string;;
+
+(* let show!int = print_int *)
+let show_int = print_int;;
+let show_int' = val_show show_int;;
+let implicit show_int';;
+
+(* let show!bool = print_bool *)
+let show_bool = print_bool;;
+let show_bool' = val_show show_bool;;
+let implicit show_bool';;
+
+(* let one = show! (incr! 0) *)
+let one = show (incr 0);;
+
+(* dynamic overloading *)
+(* ambigous:
+   
+   let show_incr = fun x -> show (incr x);;
+
+*)
+
+let show_incr =
+  fun? show incr ->
+  let show = use_show show in
+  let incr = use_incr incr in
+  fun x -> show (incr x);;
+
+(* let two = show_incr 1;; *)
+let two = show_incr 1;;
+
+(* tuples *)
+(* let show_tuple ?show!a ?show!b x =
+      (show_a (fst x)) ^ "," ^ (show_b (snd x)) *)
+
+let show_tuple =
+  fun show_a show_b ->
+  let show_a = use_show show_a in
+  let show_b = use_show show_b in
+  fun x ->
+    let (fst, snd) = x in concat (show_a fst) (show_b snd);;
+
+let show_tuple = fun? show_a show_b ->
+  val_show (show_tuple show_a show_b);;
+
+let implicit show_tuple;;
+
+(* let onetrue = show (1, true) *)
+let onetrue = show (1, true);;

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -56,10 +56,12 @@ type expression = expression_desc With_range.t
 and expression_desc =
   | Exp_var of Var_name.With_range.t
   | Exp_over of Over_path.t
+  | Exp_implicit
   | Exp_const of constant
   | Exp_fun of function_param list * expression
   | Exp_app of expression * expression
   | Exp_let of value_binding * expression
+  | Exp_let_implicit of Var_name.With_range.t * expression
   | Exp_exists of Type_var_name.With_range.t list * expression
   | Exp_forall of Type_var_name.With_range.t list * expression
   | Exp_annot of expression * core_type
@@ -79,8 +81,15 @@ and value_binding = value_binding_desc With_range.t
 
 and value_binding_desc =
   { value_binding_pat : pattern
-  ; value_binding_exp : expression
+  ; value_binding_term : term
   }
+[@@deriving sexp_of]
+
+and term = term_desc With_range.t
+
+and term_desc =
+  | Term_exp of expression
+  | Term_implicit_fun of pattern list * expression
 [@@deriving sexp_of]
 
 and case = case_desc With_range.t
@@ -128,6 +137,7 @@ type structure_item = structure_item_desc With_range.t
 
 and structure_item_desc =
   | Str_value of value_binding
+  | Str_implicit of Var_name.With_range.t
   | Str_primitive of value_description
   | Str_type of type_declaration list
 [@@deriving sexp_of]

--- a/lib/ast/ast.ml
+++ b/lib/ast/ast.ml
@@ -32,6 +32,7 @@ type pattern = pattern_desc With_range.t
 and pattern_desc =
   | Pat_any
   | Pat_var of Var_name.With_range.t
+  | Pat_over of Over_path.t
   | Pat_alias of pattern * Var_name.With_range.t
   | Pat_const of constant
   | Pat_tuple of pattern list
@@ -54,6 +55,7 @@ type expression = expression_desc With_range.t
 
 and expression_desc =
   | Exp_var of Var_name.With_range.t
+  | Exp_over of Over_path.t
   | Exp_const of constant
   | Exp_fun of function_param list * expression
   | Exp_app of expression * expression

--- a/lib/ast/ast_builder.ml
+++ b/lib/ast/ast_builder.ml
@@ -64,6 +64,9 @@ module type S = sig
     val app : (expression -> expression -> expression) with_range_fn
     val let_ : (value_binding -> in_:expression -> expression) with_range_fn
 
+    val let_implicit
+      : (Var_name.With_range.t -> in_:expression -> expression) with_range_fn
+
     val exists
       : (Type_var_name.With_range.t list -> expression -> expression) with_range_fn
 
@@ -90,12 +93,18 @@ module type S = sig
     val inst : (expression -> expression) with_range_fn
   end
 
-  val value_binding : (pattern -> expression -> value_binding) with_range_fn
+  module Term : sig
+    val exp : (expression -> term) with_range_fn
+    val implicit_fun : (pattern list -> expression -> term) with_range_fn
+  end
+
+  val value_binding : (pattern -> term -> value_binding) with_range_fn
 
   module Structure : sig
     val value : (value_binding -> structure_item) with_range_fn
     val primitive : (value_description -> structure_item) with_range_fn
     val type_ : (type_declaration list -> structure_item) with_range_fn
+    val implicit : (Var_name.With_range.t -> structure_item) with_range_fn
 
     val type_decl
       : (name:Type_name.With_range.t
@@ -185,6 +194,10 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
       With_range.create ~range @@ Exp_let (value_binding, in_)
     ;;
 
+    let let_implicit ~range var_name ~in_ =
+      With_range.create ~range @@ Exp_let_implicit (var_name, in_)
+    ;;
+
     let exists ~range type_var_names exp =
       With_range.create ~range @@ Exp_exists (type_var_names, exp)
     ;;
@@ -219,14 +232,23 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
     let inst ~range exp = With_range.create ~range @@ Exp_inst exp
   end
 
-  let value_binding ~range pat exp =
-    With_range.create ~range { value_binding_exp = exp; value_binding_pat = pat }
+  module Term = struct
+    let exp ~range exp = With_range.create ~range @@ Term_exp exp
+
+    let implicit_fun ~range pat term =
+      With_range.create ~range @@ Term_implicit_fun (pat, term)
+    ;;
+  end
+
+  let value_binding ~range pat term =
+    With_range.create ~range { value_binding_term = term; value_binding_pat = pat }
   ;;
 
   module Structure = struct
     let value ~range value_binding = With_range.create ~range @@ Str_value value_binding
     let primitive ~range value_desc = With_range.create ~range @@ Str_primitive value_desc
     let type_ ~range type_decls = With_range.create ~range @@ Str_type type_decls
+    let implicit ~range var_name = With_range.create ~range @@ Str_implicit var_name
 
     let type_decl ~range ~name ~params kind =
       With_range.create
@@ -292,6 +314,7 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
     let fun_ = Expression.fun_ ~range:R.v
     let app = Expression.app ~range:R.v
     let let_ = Expression.let_ ~range:R.v
+    let let_implicit = Expression.let_implicit ~range:R.v
     let forall = Expression.forall ~range:R.v
     let exists = Expression.exists ~range:R.v
     let annot = Expression.annot ~range:R.v
@@ -308,12 +331,18 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
     let inst = Expression.inst ~range:R.v
   end
 
+  module Term = struct
+    let exp = Term.exp ~range:R.v
+    let implicit_fun = Term.implicit_fun ~range:R.v
+  end
+
   let value_binding = value_binding ~range:R.v
 
   module Structure = struct
     let value = Structure.value ~range:R.v
     let primitive = Structure.primitive ~range:R.v
     let type_ = Structure.type_ ~range:R.v
+    let implicit = Structure.implicit ~range:R.v
     let type_decl = Structure.type_decl ~range:R.v
     let value_desc = Structure.value_desc ~range:R.v
     let constr_decl = Structure.constr_decl

--- a/lib/ast/ast_builder.ml
+++ b/lib/ast/ast_builder.ml
@@ -91,6 +91,7 @@ module type S = sig
     val case : (lhs:pattern -> rhs:expression -> case) with_range_fn
     val poly : (expression -> ?scheme:core_scheme -> unit -> expression) with_range_fn
     val inst : (expression -> expression) with_range_fn
+    val implicit : expression with_range_fn
   end
 
   module Term : sig
@@ -230,6 +231,7 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
 
     let poly ~range exp ?scheme () = With_range.create ~range @@ Exp_poly (exp, scheme)
     let inst ~range exp = With_range.create ~range @@ Exp_inst exp
+    let implicit ~range = With_range.create ~range @@ Exp_implicit
   end
 
   module Term = struct
@@ -329,6 +331,7 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
     let case = Expression.case ~range:R.v
     let poly = Expression.poly ~range:R.v
     let inst = Expression.inst ~range:R.v
+    let implicit = Expression.implicit ~range:R.v
   end
 
   module Term = struct

--- a/lib/ast/ast_builder.ml
+++ b/lib/ast/ast_builder.ml
@@ -14,6 +14,10 @@ module type S = sig
   val var_name : (string -> Var_name.With_range.t) with_range_fn
   val constr_name : (string -> Constructor_name.With_range.t) with_range_fn
   val label_name : (string -> Label_name.With_range.t) with_range_fn
+  val over_name : (string -> Over_name.With_range.t) with_range_fn
+
+  val over_path
+    : (Over_name.With_range.t -> Var_name.With_range.t -> Over_path.t) with_range_fn
 
   module Type : sig
     module Function_param : sig
@@ -35,6 +39,7 @@ module type S = sig
   module Pattern : sig
     val any : pattern with_range_fn
     val var : (Var_name.With_range.t -> pattern) with_range_fn
+    val over : (Over_path.t -> pattern) with_range_fn
     val alias : (pattern -> as_:Var_name.With_range.t -> pattern) with_range_fn
     val const : (constant -> pattern) with_range_fn
     val tuple : (pattern list -> pattern) with_range_fn
@@ -53,6 +58,7 @@ module type S = sig
     end
 
     val var : (Var_name.With_range.t -> expression) with_range_fn
+    val over : (Over_path.t -> expression) with_range_fn
     val const : (constant -> expression) with_range_fn
     val fun_ : (function_param list -> expression -> expression) with_range_fn
     val app : (expression -> expression -> expression) with_range_fn
@@ -117,6 +123,11 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
   let constr_name ~range name = With_range.create ~range @@ Constructor_name.create name
   let type_name ~range name = With_range.create ~range @@ Type_name.create name
   let label_name ~range name = With_range.create ~range @@ Label_name.create name
+  let over_name ~range name = With_range.create ~range @@ Over_name.create name
+
+  let over_path ~range qualifier var =
+    With_range.create ~range @@ { Over_path.qualifier; var }
+  ;;
 
   module Type = struct
     module Function_param = struct
@@ -142,6 +153,7 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
   module Pattern = struct
     let any ~range = With_range.create ~range Pat_any
     let var ~range var_name = With_range.create ~range @@ Pat_var var_name
+    let over ~range over_path = With_range.create ~range @@ Pat_over over_path
     let alias ~range pat ~as_ = With_range.create ~range @@ Pat_alias (pat, as_)
     let const ~range const = With_range.create ~range @@ Pat_const const
     let tuple ~range pats = With_range.create ~range @@ Pat_tuple pats
@@ -164,6 +176,7 @@ module Default : S with type 'a with_range_fn := range:Range.t -> 'a = struct
     end
 
     let var ~range var_name = With_range.create ~range @@ Exp_var var_name
+    let over ~range over_path = With_range.create ~range @@ Exp_over over_path
     let const ~range const = With_range.create ~range @@ Exp_const const
     let fun_ ~range pats exp = With_range.create ~range @@ Exp_fun (pats, exp)
     let app ~range exp1 exp2 = With_range.create ~range @@ Exp_app (exp1, exp2)
@@ -238,6 +251,8 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
   let constr_name = constr_name ~range:R.v
   let type_name = type_name ~range:R.v
   let label_name = label_name ~range:R.v
+  let over_name = over_name ~range:R.v
+  let over_path = over_path ~range:R.v
 
   module Type = struct
     module Function_param = struct
@@ -256,6 +271,7 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
   module Pattern = struct
     let any = Pattern.any ~range:R.v
     let var = Pattern.var ~range:R.v
+    let over = Pattern.over ~range:R.v
     let alias = Pattern.alias ~range:R.v
     let const = Pattern.const ~range:R.v
     let tuple = Pattern.tuple ~range:R.v
@@ -271,6 +287,7 @@ module Make (R : Range) : S with type 'a with_range_fn := 'a = struct
     end
 
     let var = Expression.var ~range:R.v
+    let over = Expression.over ~range:R.v
     let const = Expression.const ~range:R.v
     let fun_ = Expression.fun_ ~range:R.v
     let app = Expression.app ~range:R.v

--- a/lib/ast/ast_types.ml
+++ b/lib/ast/ast_types.ml
@@ -44,8 +44,25 @@ module Ident = struct
   end
 end
 
+module Over_name = Ident.Make ()
 module Var_name = Ident.Make ()
 module Type_var_name = Ident.Make ()
 module Type_name = Ident.Make ()
 module Constructor_name = Ident.Make ()
 module Label_name = Ident.Make ()
+
+module Over_path = struct
+  type t = desc With_range.t
+
+  and desc =
+    { var : Var_name.With_range.t
+    ; qualifier : Over_name.With_range.t
+    }
+  [@@deriving sexp_of]
+
+  let pp ppf (t : t) =
+    Fmt.pf ppf "%a/%a" Over_name.pp t.it.qualifier.it Var_name.pp t.it.var.it
+  ;;
+
+  let to_string = Fmt.to_to_string pp
+end

--- a/lib/ast/dune
+++ b/lib/ast/dune
@@ -1,6 +1,6 @@
 (library
  (name omniml_ast)
  (public_name omniml.ast)
- (libraries core grace)
+ (libraries core grace fmt)
  (preprocess
   (pps ppx_jane)))

--- a/lib/constraint_solver/constraint.ml
+++ b/lib/constraint_solver/constraint.ml
@@ -23,6 +23,10 @@ module Closure = struct
   ;;
 end
 
+module Implicit_scope = struct
+  type t = { vars : Var.Set.t } [@@deriving sexp]
+end
+
 module Match_error = struct
   type t =
     | Cannot_default
@@ -43,9 +47,7 @@ type t =
   | Forall of Type.Var.t list * t
   | Let of let_binding * t
   | Instance of Var.t * Type.t
-  | Over_instance of Var.t list * Type.t
-  | Let_implicit of Var.t * t
-  | Implicit of Type.t
+  | Implicit of Type.t * Implicit_scope.t
   | Match of
       { matchee : Type.Var.t
       ; closure : Closure.t
@@ -62,7 +64,6 @@ and binding =
 
 and let_binding =
   { type_vars : (flexibility * Type.Var.t) list
-  ; implicits : Type.t list
   ; in_ : t
   ; bindings : binding list
   }
@@ -88,20 +89,13 @@ let exists type_var t = Exists (type_var, t)
 let exists_many vars in_ = List.fold_right vars ~init:in_ ~f:exists
 let forall type_vars t = Forall (type_vars, t)
 let ( @: ) x type_ = { binding_var = x; binding_type = type_ }
-let mono_binding bindings = { type_vars = []; implicits = []; in_ = tt; bindings }
-let ( @?-> ) t1 t2 = t1, t2
+let mono_binding bindings = { type_vars = []; in_ = tt; bindings }
 let ( @=> ) t1 t2 = t1, t2
 let ( @. ) t1 t2 = t1, t2
-
-let poly_binding (type_vars, (implicits, (in_, bindings))) =
-  { type_vars; implicits; in_; bindings }
-;;
-
+let poly_binding (type_vars, (in_, bindings)) = { type_vars; in_; bindings }
 let let_ binding ~in_ = Let (binding, in_)
 let inst x type_ = Instance (x, type_)
-let over xs type_ = Over_instance (xs, type_)
-let let_implicit var ~in_ = Let_implicit (var, in_)
-let implicit type_ = Implicit type_
+let implicit type_ ~in_:scope = Implicit (type_, scope)
 
 let match_ matchee ~closure ~with_ ~else_ ~error =
   Match { matchee; closure = Closure.of_list closure; case = with_; else_; error }

--- a/lib/constraint_solver/constraint.ml
+++ b/lib/constraint_solver/constraint.ml
@@ -44,6 +44,8 @@ type t =
   | Let of let_binding * t
   | Instance of Var.t * Type.t
   | Over_instance of Var.t list * Type.t
+  | Let_implicit of Var.t * t
+  | Implicit of Type.t
   | Match of
       { matchee : Type.Var.t
       ; closure : Closure.t
@@ -60,6 +62,7 @@ and binding =
 
 and let_binding =
   { type_vars : (flexibility * Type.Var.t) list
+  ; implicits : Type.t list
   ; in_ : t
   ; bindings : binding list
   }
@@ -85,13 +88,20 @@ let exists type_var t = Exists (type_var, t)
 let exists_many vars in_ = List.fold_right vars ~init:in_ ~f:exists
 let forall type_vars t = Forall (type_vars, t)
 let ( @: ) x type_ = { binding_var = x; binding_type = type_ }
-let mono_binding bindings = { type_vars = []; in_ = tt; bindings }
+let mono_binding bindings = { type_vars = []; implicits = []; in_ = tt; bindings }
+let ( @?-> ) t1 t2 = t1, t2
 let ( @=> ) t1 t2 = t1, t2
 let ( @. ) t1 t2 = t1, t2
-let poly_binding (type_vars, (in_, bindings)) = { type_vars; in_; bindings }
+
+let poly_binding (type_vars, (implicits, (in_, bindings))) =
+  { type_vars; implicits; in_; bindings }
+;;
+
 let let_ binding ~in_ = Let (binding, in_)
 let inst x type_ = Instance (x, type_)
 let over xs type_ = Over_instance (xs, type_)
+let let_implicit var ~in_ = Let_implicit (var, in_)
+let implicit type_ = Implicit type_
 
 let match_ matchee ~closure ~with_ ~else_ ~error =
   Match { matchee; closure = Closure.of_list closure; case = with_; else_; error }

--- a/lib/constraint_solver/constraint.ml
+++ b/lib/constraint_solver/constraint.ml
@@ -43,6 +43,7 @@ type t =
   | Forall of Type.Var.t list * t
   | Let of let_binding * t
   | Instance of Var.t * Type.t
+  | Over_instance of Var.t list * Type.t
   | Match of
       { matchee : Type.Var.t
       ; closure : Closure.t
@@ -90,6 +91,7 @@ let ( @. ) t1 t2 = t1, t2
 let poly_binding (type_vars, (in_, bindings)) = { type_vars; in_; bindings }
 let let_ binding ~in_ = Let (binding, in_)
 let inst x type_ = Instance (x, type_)
+let over xs type_ = Over_instance (xs, type_)
 
 let match_ matchee ~closure ~with_ ~else_ ~error =
   Match { matchee; closure = Closure.of_list closure; case = with_; else_; error }

--- a/lib/constraint_solver/decoded_type.ml
+++ b/lib/constraint_solver/decoded_type.ml
@@ -27,6 +27,10 @@ module Pretter_printer = struct
     Fmt.pf ppf "@[%a ->@ %a@]" pp_lhs lhs pp_rhs rhs
   ;;
 
+  let[@inline] pp_implicit_arrow pp_lhs pp_rhs ppf (lhs, rhs) =
+    Fmt.pf ppf "@[%a =>@ %a@]" pp_lhs lhs pp_rhs rhs
+  ;;
+
   let[@inline] pp_tuple pp_type ppf types =
     Fmt.(pf ppf "@[<0>%a@]" (list ~sep:(any " *@ ") pp_type) types)
   ;;
@@ -56,7 +60,12 @@ module Pretter_printer = struct
     ;;
 
     let rec pp ppf (t : Type.t) =
-      let rec pp_lvl_arrow ppf (t : Type.t) =
+      let rec pp_lvl_implicit_arrow ppf (t : Type.t) =
+        match t with
+        | Implicit_arrow (t1, t2) | Shape ([ t1; t2 ], Sh_implicit_arrow) ->
+          pp_arrow pp_lvl_arrow pp_lvl_implicit_arrow ppf (t1, t2)
+        | t -> pp_lvl_arrow ppf t
+      and pp_lvl_arrow ppf (t : Type.t) =
         match t with
         | Arrow (t1, t2) | Shape ([ t1; t2 ], Sh_arrow) ->
           pp_arrow pp_lvl_tuple pp_lvl_arrow ppf (t1, t2)
@@ -79,11 +88,12 @@ module Pretter_printer = struct
         | Poly scheme -> Fmt.pf ppf "@[[%a]@]" pp_scheme scheme
         | t -> Fmt.parens pp_lvl_arrow ppf t
       in
-      pp_lvl_arrow ppf t
+      pp_lvl_implicit_arrow ppf t
 
     and pp_shape ppf (shape : Principal_shape.t) =
       match shape with
       | Sh_arrow -> Fmt.string ppf "(->)"
+      | Sh_implicit_arrow -> Fmt.string ppf "(=>)"
       | Sh_tuple n -> Fmt.pf ppf "Pi^%d" n
       | Sh_constr (n, constr) -> Fmt.pf ppf "%a(%d)" pp_ident constr n
       | Sh_poly { quantifiers; scheme } ->

--- a/lib/constraint_solver/decoded_type.ml
+++ b/lib/constraint_solver/decoded_type.ml
@@ -86,7 +86,7 @@ module Pretter_printer = struct
         match t with
         | Var var -> pp_var ppf var
         | Poly scheme -> Fmt.pf ppf "@[[%a]@]" pp_scheme scheme
-        | t -> Fmt.parens pp_lvl_arrow ppf t
+        | t -> Fmt.parens pp_lvl_implicit_arrow ppf t
       in
       pp_lvl_implicit_arrow ppf t
 
@@ -121,6 +121,11 @@ module Pretter_printer = struct
       let rec pp_lvl_mu ppf t =
         match t with
         | Mu (var, t) -> Fmt.pf ppf "@[%a@ as %a@]" pp_lvl_mu t pp_var var
+        | t -> pp_lvl_implicit_arrow ppf t
+      and pp_lvl_implicit_arrow ppf t =
+        match t with
+        | App ([ t1; t2 ], Sh_implicit_arrow) ->
+          pp_implicit_arrow pp_lvl_arrow pp_lvl_implicit_arrow ppf (t1, t2)
         | t -> pp_lvl_arrow ppf t
       and pp_lvl_arrow ppf t =
         match t with

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -450,7 +450,6 @@ end
 module Scheme = struct
   type t =
     { root : Type.t
-    ; implicits : Type.t list
     ; region : Region.t
     }
   [@@deriving sexp_of]
@@ -467,8 +466,7 @@ module Scheme = struct
         | Generic -> Type.inner type_ |> I.iter ~f:loop
         | Instance _ -> f type_)
     in
-    loop t.root;
-    List.iter t.implicits ~f:loop
+    loop t.root
   ;;
 end
 
@@ -993,10 +991,7 @@ let update_and_generalize ~state (curr_region : Region.t) =
   [%log.global.debug "End generalization" (curr_region.id : Identifier.t)]
 ;;
 
-let create_scheme ~curr_region ?(implicits = []) root : Scheme.t =
-  { root; implicits; region = curr_region }
-;;
-
+let create_scheme ~curr_region root : Scheme.t = { root; region = curr_region }
 let run_scheduler () = Scheduler.(run (t ()))
 
 let force_generalization ~state region =
@@ -1035,7 +1030,7 @@ let force_root_generalization_and_return_unsolved_shape_var_errors ~state =
   collected_errors @ List.concat_map remaining_shape_vars ~f:Principal_shape.Var.errors
 ;;
 
-let instantiate ~state ~curr_region ({ root; implicits; region = src_region } : Scheme.t) =
+let instantiate ~state ~curr_region ({ root; region = src_region } : Scheme.t) =
   [%log.global.debug
     "Generalization tree @ instantiation"
       (state.region_tree : Type.t Pool.t Tree.With_dirty.t)];
@@ -1051,8 +1046,6 @@ let instantiate ~state ~curr_region ({ root; implicits; region = src_region } : 
   in
   (* Copy the root *)
   let root = copy root in
-  (* Copy the implicits *)
-  let implicits = List.map implicits ~f:copy in
   (* Return copied quantifiers. Note that this is delayed since 
      the quantifiers can mutate as partial generalization progresses. *)
   let quantifiers () =
@@ -1061,7 +1054,7 @@ let instantiate ~state ~curr_region ({ root; implicits; region = src_region } : 
     |> Hashtbl.filter_map ~f:(fun copy -> Option.some_if copy.is_quantifier copy.it)
     |> Hashtbl.data
   in
-  quantifiers, implicits, root
+  quantifiers, root
 ;;
 
 module Suspended_match = struct

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -424,6 +424,7 @@ end
 module Scheme = struct
   type t =
     { root : Type.t
+    ; implicits : Type.t list
     ; region : Region.t
     }
   [@@deriving sexp_of]
@@ -440,7 +441,8 @@ module Scheme = struct
         | Generic -> Type.inner type_ |> I.iter ~f:loop
         | Instance _ -> f type_)
     in
-    loop t.root
+    loop t.root;
+    List.iter t.implicits ~f:loop
   ;;
 end
 
@@ -519,53 +521,55 @@ let rec prune_structure ~(state : State.t) structure instances =
 (** [copy ~state type_ ~instance_id ~src_region ~dst_region] copies the type [type_] 
     in the [src_region] region to a fresh type in the [dst_region] region. Any 
     instantiation edges are associated with the instance id [instance_id].  *)
-and copy ~(state : State.t) type_ ~instance_id ~src_region ~dst_region =
+and copy ~(state : State.t) ~instance_id ~src_region ~dst_region =
   let generic_copies = Hashtbl.create (module Identifier) in
-  let rec visit type_ =
-    if Tree.compare_node_by_level (Type.region type_) src_region < 0
-    then type_
-    else (
-      match Type.status type_ with
-      | Generic -> find_or_alloc_generic_copy type_
-      | Instance _ ->
-        (* The type is an instance, but a member of the region. Meaning it 
+  fun type_ ->
+    let rec visit type_ =
+      if Tree.compare_node_by_level (Type.region type_) src_region < 0
+      then type_
+      else (
+        match Type.status type_ with
+        | Generic -> find_or_alloc_generic_copy type_
+        | Instance _ ->
+          (* The type is an instance, but a member of the region. Meaning it 
            could be generic in the future. So we create an instantiation 
            edge. *)
-        find_or_alloc_instance_copy type_)
-  and alloc_copy ~on_alloc type_ =
-    let copy = create_var ~state ~curr_region:dst_region () in
-    on_alloc copy;
-    let inner = Type.inner type_ in
-    let flexized_inner = if Type.is_generic type_ then inner else flexize_inner inner in
-    let inner_copy = I.map flexized_inner ~f:visit in
-    unify
-      ~state
-      ~curr_region:dst_region
+          find_or_alloc_instance_copy type_)
+    and alloc_copy ~on_alloc type_ =
+      let copy = create_var ~state ~curr_region:dst_region () in
+      on_alloc copy;
+      let inner = Type.inner type_ in
+      let flexized_inner = if Type.is_generic type_ then inner else flexize_inner inner in
+      let inner_copy = I.map flexized_inner ~f:visit in
+      unify
+        ~state
+        ~curr_region:dst_region
+        copy
+        (Type.create ~state ~curr_region:dst_region inner_copy);
       copy
-      (Type.create ~state ~curr_region:dst_region inner_copy);
-    copy
-  and find_or_alloc_generic_copy type_ =
-    let id = Type.id type_ in
-    try Hashtbl.find_exn generic_copies id with
-    | Not_found_s _ ->
-      alloc_copy
-        ~on_alloc:(fun copy -> Hashtbl.set generic_copies ~key:id ~data:copy)
-        type_
-  and find_or_alloc_instance_copy type_ =
-    try
-      let _from, instance = Map.find_exn (Type.instances type_) instance_id in
-      (* Invariant: [from = src_region] *)
-      instance
-    with
-    | Not_found_s _ ->
-      alloc_copy
-        ~on_alloc:(fun instance ->
-          [%log.global.debug "Adding instance guard" (type_ : Type.t) (instance : Type.t)];
-          Type.add_guard ~state instance;
-          Type.add_instance ~state type_ instance_id (src_region, instance))
-        type_
-  in
-  visit type_
+    and find_or_alloc_generic_copy type_ =
+      let id = Type.id type_ in
+      try Hashtbl.find_exn generic_copies id with
+      | Not_found_s _ ->
+        alloc_copy
+          ~on_alloc:(fun copy -> Hashtbl.set generic_copies ~key:id ~data:copy)
+          type_
+    and find_or_alloc_instance_copy type_ =
+      try
+        let _from, instance = Map.find_exn (Type.instances type_) instance_id in
+        (* Invariant: [from = src_region] *)
+        instance
+      with
+      | Not_found_s _ ->
+        alloc_copy
+          ~on_alloc:(fun instance ->
+            [%log.global.debug
+              "Adding instance guard" (type_ : Type.t) (instance : Type.t)];
+            Type.add_guard ~state instance;
+            Type.add_instance ~state type_ instance_id (src_region, instance))
+          type_
+    in
+    visit type_
 
 and unify ~(state : State.t) ~curr_region type1 type2 =
   let remove_guard_worklist = Queue.create () in
@@ -929,7 +933,10 @@ let update_and_generalize ~state (curr_region : Region.t) =
   [%log.global.debug "End generalization" (curr_region.id : Identifier.t)]
 ;;
 
-let create_scheme ~curr_region root : Scheme.t = { root; region = curr_region }
+let create_scheme ~curr_region ?(implicits = []) root : Scheme.t =
+  { root; implicits; region = curr_region }
+;;
+
 let run_scheduler () = Scheduler.(run (t ()))
 
 let force_generalization ~state region =
@@ -968,7 +975,7 @@ let force_root_generalization_and_return_unsolved_shape_var_errors ~state =
   collected_errors @ List.concat_map remaining_shape_vars ~f:Principal_shape.Var.errors
 ;;
 
-let instantiate ~state ~curr_region ({ root; region = src_region } : Scheme.t) =
+let instantiate ~state ~curr_region ({ root; implicits; region = src_region } : Scheme.t) =
   [%log.global.debug
     "Generalization tree @ instantiation"
       (state.region_tree : Type.t Pool.t Tree.With_dirty.t)];
@@ -976,8 +983,13 @@ let instantiate ~state ~curr_region ({ root; region = src_region } : Scheme.t) =
   force_generalization ~state src_region;
   (* Create an instance group *)
   let instance_id = Instance_identifier.create state.id_source in
-  (* Copy the type *)
-  copy ~state ~src_region ~dst_region:curr_region ~instance_id root
+  (* Create a new copy scope *)
+  let copy = copy ~state ~src_region ~dst_region:curr_region ~instance_id in
+  (* Copy the root *)
+  let root = copy root in
+  (* Copy the implicits *)
+  let implicits = List.map implicits ~f:copy in
+  implicits, root
 ;;
 
 module Suspended_match = struct

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -239,6 +239,30 @@ end
 module U = Unifier.Make (S)
 module Type0 = U.Term
 
+module Copy_scope0 = struct
+  module Copy = struct
+    type t =
+      { it : Type0.t
+      ; is_quantifier : bool
+        (** [is_quantifier] is set to true if the copy 
+            is of a generic variable. *)
+      }
+    [@@deriving sexp_of]
+  end
+
+  type t = { generic_copies : (Identifier.t, Copy.t) Hashtbl.t } [@@deriving sexp_of]
+
+  let create_scope () = { generic_copies = Hashtbl.create (module Identifier) }
+
+  module State = struct
+    type nonrec t = (Instance_identifier.t, t) Hashtbl.t [@@deriving sexp_of]
+
+    let create () = Hashtbl.create (module Identifier)
+    let add t iid copy = Hashtbl.set t ~key:iid ~data:copy
+    let find_or_add t iid = Hashtbl.find_or_add t iid ~default:create_scope
+  end
+end
+
 module State = struct
   type t =
     { id_source : (Identifier.source[@sexp.opaque])
@@ -246,6 +270,7 @@ module State = struct
     ; alive_regions : (Identifier.t, Type0.t Region0.t) Hashtbl.t
     ; shape_var_state : Principal_shape.Var.State.t
     ; defaulting : Omniml_options.Defaulting.t
+    ; copy_scope_state : Copy_scope0.State.t
     }
   [@@deriving sexp_of]
 
@@ -268,6 +293,7 @@ module State = struct
     ; shape_var_state
     ; alive_regions = Hashtbl.create (module Identifier)
     ; defaulting
+    ; copy_scope_state = Copy_scope0.State.create ()
     }
   ;;
 
@@ -446,6 +472,25 @@ module Scheme = struct
   ;;
 end
 
+module Copy_scope = struct
+  include Copy_scope0
+
+  let with_ ~state ~instance_id f =
+    (* TODO: This leaks memory, since all instantiations are kept in the 
+       state. We never collect until the end of solving. *)
+    let scope = State.find_or_add state instance_id in
+    f scope
+  ;;
+
+  let find t type_ = Hashtbl.find t.generic_copies (Type.id type_)
+  let find_it t type_ = find t type_ |> Option.map ~f:(fun copy -> copy.it)
+
+  let register t type_ copy =
+    let copy = { Copy.it = copy; is_quantifier = Type.is_var type_ } in
+    Hashtbl.set t.generic_copies ~key:(Type.id type_) ~data:copy
+  ;;
+end
+
 let create_var ~state ~curr_region () = Type.create ~state ~curr_region Var
 
 let create_shape_var ~(state : State.t) ~curr_region () =
@@ -518,58 +563,69 @@ let rec prune_structure ~(state : State.t) structure instances =
     [%log.global.debug "Copy" (copy : Type.t)];
     unify ~state ~curr_region:dst_region copy instance)
 
-(** [copy ~state type_ ~instance_id ~src_region ~dst_region] copies the type [type_] 
-    in the [src_region] region to a fresh type in the [dst_region] region. Any 
-    instantiation edges are associated with the instance id [instance_id].  *)
-and copy ~(state : State.t) ~instance_id ~src_region ~dst_region =
-  let generic_copies = Hashtbl.create (module Identifier) in
-  fun type_ ->
-    let rec visit type_ =
-      if Tree.compare_node_by_level (Type.region type_) src_region < 0
-      then type_
-      else (
-        match Type.status type_ with
-        | Generic -> find_or_alloc_generic_copy type_
-        | Instance _ ->
-          (* The type is an instance, but a member of the region. Meaning it 
+and copy ~state ~instance_id ~src_region ~dst_region type_ =
+  Copy_scope.with_ ~state:state.copy_scope_state ~instance_id
+  @@ fun copy_scope ->
+  copy_with_scope ~state ~instance_id ~src_region ~dst_region ~copy_scope type_
+
+(** [copy_with_scope ~state type_ ~instance_id ~src_region ~dst_region ~copy_scope] 
+    copies the type [type_] in the [src_region] region to a fresh type in the 
+    [dst_region] region. Any instantiation edges are associated with the instance id 
+    [instance_id].  
+
+    Invariant: the passed in [copy_scope] is expected to be registered with 
+    instance id [instance_id] in [state]. *)
+and copy_with_scope
+      ~(state : State.t)
+      ~instance_id
+      ~src_region
+      ~dst_region
+      ~copy_scope
+      type_
+  =
+  let rec visit type_ =
+    if Tree.compare_node_by_level (Type.region type_) src_region < 0
+    then type_
+    else (
+      match Type.status type_ with
+      | Generic -> find_or_alloc_generic_copy type_
+      | Instance _ ->
+        (* The type is an instance, but a member of the region. Meaning it 
            could be generic in the future. So we create an instantiation 
            edge. *)
-          find_or_alloc_instance_copy type_)
-    and alloc_copy ~on_alloc type_ =
-      let copy = create_var ~state ~curr_region:dst_region () in
-      on_alloc copy;
-      let inner = Type.inner type_ in
-      let flexized_inner = if Type.is_generic type_ then inner else flexize_inner inner in
-      let inner_copy = I.map flexized_inner ~f:visit in
-      unify
-        ~state
-        ~curr_region:dst_region
-        copy
-        (Type.create ~state ~curr_region:dst_region inner_copy);
+        find_or_alloc_instance_copy type_)
+  and alloc_copy ~on_alloc type_ =
+    let copy = create_var ~state ~curr_region:dst_region () in
+    on_alloc copy;
+    let inner = Type.inner type_ in
+    let flexized_inner = if Type.is_generic type_ then inner else flexize_inner inner in
+    let inner_copy = I.map flexized_inner ~f:visit in
+    unify
+      ~state
+      ~curr_region:dst_region
       copy
-    and find_or_alloc_generic_copy type_ =
-      let id = Type.id type_ in
-      try Hashtbl.find_exn generic_copies id with
-      | Not_found_s _ ->
-        alloc_copy
-          ~on_alloc:(fun copy -> Hashtbl.set generic_copies ~key:id ~data:copy)
-          type_
-    and find_or_alloc_instance_copy type_ =
-      try
-        let _from, instance = Map.find_exn (Type.instances type_) instance_id in
-        (* Invariant: [from = src_region] *)
-        instance
-      with
-      | Not_found_s _ ->
-        alloc_copy
-          ~on_alloc:(fun instance ->
-            [%log.global.debug
-              "Adding instance guard" (type_ : Type.t) (instance : Type.t)];
-            Type.add_guard ~state instance;
-            Type.add_instance ~state type_ instance_id (src_region, instance))
-          type_
-    in
-    visit type_
+      (Type.create ~state ~curr_region:dst_region inner_copy);
+    copy
+  and find_or_alloc_generic_copy type_ =
+    match Copy_scope.find_it copy_scope type_ with
+    | Some copy -> copy
+    | None ->
+      alloc_copy ~on_alloc:(fun copy -> Copy_scope.register copy_scope type_ copy) type_
+  and find_or_alloc_instance_copy type_ =
+    try
+      let _from, instance = Map.find_exn (Type.instances type_) instance_id in
+      (* Invariant: [from = src_region] *)
+      instance
+    with
+    | Not_found_s _ ->
+      alloc_copy
+        ~on_alloc:(fun instance ->
+          [%log.global.debug "Adding instance guard" (type_ : Type.t) (instance : Type.t)];
+          Type.add_guard ~state instance;
+          Type.add_instance ~state type_ instance_id (src_region, instance))
+        type_
+  in
+  visit type_
 
 and unify ~(state : State.t) ~curr_region type1 type2 =
   let remove_guard_worklist = Queue.create () in
@@ -833,8 +889,12 @@ let rigid_scope_check (generation : Generation.t) =
 let unsafe_generalize ~state type_ =
   if Type.is_unguarded type_
   then (
-    Map.iter (Type.instances type_) ~f:(fun (_from, instance) ->
-      Type.remove_guard ~state instance);
+    Map.iteri (Type.instances type_) ~f:(fun ~key:iid ~data:(_from, instance) ->
+      (* Remove the guard *)
+      Type.remove_guard ~state instance;
+      (* Register the instance as a generic copy in the copy scope *)
+      Copy_scope.with_ ~state:state.copy_scope_state ~instance_id:iid
+      @@ fun copy_scope -> Copy_scope.register copy_scope type_ instance);
     (* Safety: [type_] is being generalized, there is no 
        point setting it's write barrier (and dirty bit). *)
     Type.unsafe_update_structure type_ (fun structure ->
@@ -984,12 +1044,24 @@ let instantiate ~state ~curr_region ({ root; implicits; region = src_region } : 
   (* Create an instance group *)
   let instance_id = Instance_identifier.create state.id_source in
   (* Create a new copy scope *)
-  let copy = copy ~state ~src_region ~dst_region:curr_region ~instance_id in
+  Copy_scope.with_ ~state:state.copy_scope_state ~instance_id
+  @@ fun copy_scope ->
+  let copy =
+    copy_with_scope ~state ~instance_id ~src_region ~dst_region:curr_region ~copy_scope
+  in
   (* Copy the root *)
   let root = copy root in
   (* Copy the implicits *)
   let implicits = List.map implicits ~f:copy in
-  implicits, root
+  (* Return copied quantifiers. Note that this is delayed since 
+     the quantifiers can mutate as partial generalization progresses. *)
+  let quantifiers () =
+    (* All quantifiers must be generic *)
+    copy_scope.generic_copies
+    |> Hashtbl.filter_map ~f:(fun copy -> Option.some_if copy.is_quantifier copy.it)
+    |> Hashtbl.data
+  in
+  quantifiers, implicits, root
 ;;
 
 module Suspended_match = struct

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -998,7 +998,7 @@ module Suspended_match = struct
     ; closure : closure
     ; case : shape:Principal_shape.t -> args:Type.t list -> unit
     ; else_ : unit -> Principal_shape.t
-    ; error : Constraint.Match_error.t -> Omniml_error.t
+    ; error : Constraint.Match_error.t -> Omniml_error.t option
     }
   [@@deriving sexp_of]
 
@@ -1096,6 +1096,7 @@ module Suspended_match = struct
                    let actual = Principal_shape.Var.peek_exn svar in
                    let report =
                      error (Inconsistent_default { actual; expected = default_shape })
+                     |> Option.value_exn ~here:[%here]
                    in
                    raise (Inconsistent_defaults report));
                 [%log.global.debug
@@ -1128,7 +1129,9 @@ module Suspended_match = struct
         [%message
           "Kind mismatch when adding matchee handler. Expected type, got args."
             (matchee : Type.t)]
-    | Structure Rigid_var -> raise (Cannot_match_on_rigid (error Matchee_is_rigid))
+    | Structure Rigid_var ->
+      raise
+        (Cannot_match_on_rigid (error Matchee_is_rigid |> Option.value_exn ~here:[%here]))
     | Structure (Structure (Structure { args; shape })) ->
       (* Optimisation: Immediately solve the case *)
       case ~shape ~args;

--- a/lib/constraint_solver/generalization.ml
+++ b/lib/constraint_solver/generalization.ml
@@ -984,7 +984,7 @@ module Suspended_match = struct
   type t =
     { matchee : Type.t
     ; closure : closure
-    ; case : curr_region:Region.t -> shape:Principal_shape.t -> args:Type.t list -> unit
+    ; case : shape:Principal_shape.t -> args:Type.t list -> unit
     ; else_ : unit -> Principal_shape.t
     ; error : Constraint.Match_error.t -> Omniml_error.t
     }
@@ -1055,54 +1055,59 @@ module Suspended_match = struct
     in
     let add_handler ~shape_args svar =
       [%log.global.debug "Adding handler" (svar : Principal_shape.Var.t)];
-      Principal_shape.Var.add_handler
-        svar
-        { run =
-            (fun shape ->
-              let args = get_or_alloc_matchee_args () in
-              (* Remove guard from closure *)
-              closure_remove_guard ~state ~shape_args closure;
-              (* Solve case *)
-              case ~curr_region ~shape ~args;
-              [%log.global.debug
-                "Generalization tree after solving case"
-                  (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
-        ; default =
-            (fun () ->
-              [%log.global.debug
-                "Default handler triggered" (svar : Principal_shape.Var.t)];
-              let default_shape = else_ () in
-              [%log.global.debug "Default shape" (default_shape : Principal_shape.t)];
-              (try
-                 Principal_shape.Var.fill_exn
-                   ~state:state.shape_var_state
-                   svar
-                   default_shape
-               with
-               | Principal_shape.Var.Not_empty ->
-                 let actual = Principal_shape.Var.peek_exn svar in
-                 let report =
-                   error (Inconsistent_default { actual; expected = default_shape })
-                 in
-                 raise (Inconsistent_defaults report));
-              [%log.global.debug
-                "Generalization tree running default handler"
-                  (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
-        ; error = (fun () -> error Cannot_default)
-        };
+      let handler =
+        Principal_shape.Var.add_handler
+          svar
+          { run =
+              (fun shape ->
+                let args = get_or_alloc_matchee_args () in
+                (* Remove guard from closure *)
+                closure_remove_guard ~state ~shape_args closure;
+                (* Solve case *)
+                case ~shape ~args;
+                [%log.global.debug
+                  "Generalization tree after solving case"
+                    (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
+          ; default =
+              (fun () ->
+                [%log.global.debug
+                  "Default handler triggered" (svar : Principal_shape.Var.t)];
+                let default_shape = else_ () in
+                [%log.global.debug "Default shape" (default_shape : Principal_shape.t)];
+                (try
+                   Principal_shape.Var.fill_exn
+                     ~state:state.shape_var_state
+                     svar
+                     default_shape
+                 with
+                 | Principal_shape.Var.Not_empty ->
+                   let actual = Principal_shape.Var.peek_exn svar in
+                   let report =
+                     error (Inconsistent_default { actual; expected = default_shape })
+                   in
+                   raise (Inconsistent_defaults report));
+                [%log.global.debug
+                  "Generalization tree running default handler"
+                    (state.region_tree : Type.t Pool.t Tree.With_dirty.t)])
+          ; cancel = (fun () -> closure_remove_guard ~state ~shape_args closure)
+          ; error = (fun () -> error Cannot_default)
+          }
+      in
       (* Add guard to closure *)
-      closure_add_guard ~state ~shape_args closure
+      closure_add_guard ~state ~shape_args closure;
+      handler
     in
     match Type.inner matchee with
     | Var ->
       let shape_var = create_shape_var ~state ~curr_region () in
       let shape_args = create_var ~state ~curr_region () in
-      add_handler ~shape_args shape_var;
+      let handler = add_handler ~shape_args shape_var in
       unify
         ~state
         ~curr_region
         matchee
-        (create_shape_app ~state ~curr_region shape_args shape_var)
+        (create_shape_app ~state ~curr_region shape_args shape_var);
+      handler
     | Structure (Structure (Shape_app { args = shape_args; shape_var })) ->
       add_handler ~shape_args shape_var
     | Structure (Structure (Shape_args _)) ->
@@ -1114,6 +1119,7 @@ module Suspended_match = struct
     | Structure Rigid_var -> raise (Cannot_match_on_rigid (error Matchee_is_rigid))
     | Structure (Structure (Structure { args; shape })) ->
       (* Optimisation: Immediately solve the case *)
-      case ~curr_region ~shape ~args
+      case ~shape ~args;
+      None
   ;;
 end

--- a/lib/constraint_solver/omniml_constraint_solver.ml
+++ b/lib/constraint_solver/omniml_constraint_solver.ml
@@ -19,6 +19,7 @@ module For_testing = struct
     type type_ = Type.t =
       | Var of Type.Var.t
       | Arrow of type_ * type_
+      | Implicit_arrow of type_ * type_
       | Tuple of type_ list
       | Constr of type_ list * Type.Ident.t
       | Shape of type_ list * principal_shape
@@ -39,6 +40,7 @@ module For_testing = struct
 
     and principal_shape = Principal_shape.t =
       | Sh_arrow [@quickcheck.do_not_generate]
+      | Sh_implicit_arrow [@quickcheck.do_not_generate]
       | Sh_tuple of int
       | Sh_constr of int * Type.Ident.t
       | Sh_poly of poly_principal_shape [@quickcheck.do_not_generate]

--- a/lib/constraint_solver/omniml_constraint_solver.ml
+++ b/lib/constraint_solver/omniml_constraint_solver.ml
@@ -4,6 +4,7 @@ module Type = Type
 module Constraint = Constraint
 module Decoded_type = Decoded_type
 module Error = Solver.Error
+module Termination = Solver.Termination
 
 let solve = Solver.solve
 

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -196,23 +196,23 @@ module Constraint : sig
       this syntax. *)
 
   type unquantified_let_binding := t * binding list
-
-  type quantified_let_binding :=
-    (flexibility * Type.Var.t) list * unquantified_let_binding
+  type abstracted_let_binding := Type.t list * unquantified_let_binding
+  type quantified_let_binding := (flexibility * Type.Var.t) list * abstracted_let_binding
 
   val ( @=> ) : t -> binding list -> unquantified_let_binding
+  val ( @?-> ) : Type.t list -> unquantified_let_binding -> abstracted_let_binding
 
   val ( @. )
     :  (flexibility * Type.Var.t) list
-    -> unquantified_let_binding
+    -> abstracted_let_binding
     -> quantified_let_binding
 
   (** [mono_binding bindings] builds a monomorphic let binding.
       This is equivalent to [poly_binding ([] @. tt @=> bindings)]. *)
   val mono_binding : binding list -> let_binding
 
-  (** [poly_binding (vs @. c @=> bindings)] builds the constrained let binding
-      [forall vs. c => bindings]. *)
+  (** [poly_binding (vs @. ts @?> c @=> bindings)] builds the constrained let binding
+      [forall vs. ?ts -> c => bindings]. *)
   val poly_binding : quantified_let_binding -> let_binding
 
   (** [let_ binding ~in_:c] binds the variables in [binding] in [c]. *)
@@ -223,6 +223,8 @@ module Constraint : sig
   val inst : Var.t -> Type.t -> t
 
   val over : Var.t list -> Type.t -> t
+  val let_implicit : Var.t -> in_:t -> t
+  val implicit : Type.t -> t
 
   module Match_error : sig
     type t =

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -276,8 +276,14 @@ module Constraint : sig
 end
 
 module Decoded_type : sig
+  module Var : Var.S
+
   (** A type produced by the constraint solver. *)
-  type t [@@deriving sexp]
+  type t =
+    | Var of Var.t
+    | App of t list * Principal_shape.t
+    | Mu of Var.t * t
+  [@@deriving sexp]
 
   include Pretty_printer.S with type t := t
 end
@@ -317,7 +323,7 @@ module Termination : sig
         {[ 
            W ::= ? | s
         ]} *)
-    type t
+    type t [@@deriving sexp_of]
 
     module Spine : sig
       (** A witness spine is a partial term of the form: 
@@ -328,12 +334,19 @@ module Termination : sig
           This represents a term inferred by an implicit hole.  *)
       type witness := t
 
-      type t
+      type t [@@deriving sexp_of]
 
       val head : t -> Constraint.Var.t
       val instantiation : t -> Decoded_type.t list Elab.t
       val args : t -> witness list
     end
+
+    type view =
+      | Hole
+      | Spine of Spine.t
+    [@@deriving sexp_of]
+
+    val view : t -> view
   end
 
   module Check : sig
@@ -352,6 +365,12 @@ module Termination : sig
             one-hole witness context. *)
       }
     [@@deriving sexp_of]
+
+    (** [disabled] is a check that effectively acts as no termination check exists. *)
+    val disabled : t
+
+    (** [threshold n] is a check that fails when a given variable occurs recursively [>= n] times. *)
+    val threshold : int -> t
   end
 end
 

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -63,6 +63,9 @@ module Type : sig
   (** [poly s] embeds a type scheme as a (mono)type. *)
   val poly : Scheme.t -> t
 
+  (** [a @=> b] is the implicit function type [a => b]. *)
+  val ( @=> ) : t -> t -> t
+
   module Matchee : sig
     (** A "pattern" used by {!Constraint.match_}.
 

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -222,6 +222,8 @@ module Constraint : sig
       bound to [x]. The variable [x] must be bound earlier by {!let_}. *)
   val inst : Var.t -> Type.t -> t
 
+  val over : Var.t list -> Type.t -> t
+
   module Match_error : sig
     type t =
       | Cannot_default

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -74,6 +74,9 @@ module Type : sig
       | Arrow of Var.t * Var.t
       (** [Arrow (arg, ret)] is a function type with argument [arg]
           and result [ret] variables. *)
+      | Implicit_arrow of Var.t * Var.t
+      (** [Implicit_arrow (arg, ret)] is a implicit function type with 
+          argument [arg] and result [ret] variables. *)
       | Tuple of Var.t list
       (** [Tuple vs] is a tuple type with component variables [vs]. *)
       | Constr of Var.t list * Ident.t
@@ -130,6 +133,11 @@ module Constraint : sig
       ; vars : Var.t list
       }
     [@@deriving sexp]
+  end
+
+  module Implicit_scope : sig
+    (** A set of variables used for implicit resolution. *)
+    type t = { vars : Var.Set.t } [@@deriving sexp]
   end
 
   (** [t] is a constraint. *)
@@ -196,15 +204,15 @@ module Constraint : sig
       this syntax. *)
 
   type unquantified_let_binding := t * binding list
-  type abstracted_let_binding := Type.t list * unquantified_let_binding
-  type quantified_let_binding := (flexibility * Type.Var.t) list * abstracted_let_binding
+
+  type quantified_let_binding :=
+    (flexibility * Type.Var.t) list * unquantified_let_binding
 
   val ( @=> ) : t -> binding list -> unquantified_let_binding
-  val ( @?-> ) : Type.t list -> unquantified_let_binding -> abstracted_let_binding
 
   val ( @. )
     :  (flexibility * Type.Var.t) list
-    -> abstracted_let_binding
+    -> unquantified_let_binding
     -> quantified_let_binding
 
   (** [mono_binding bindings] builds a monomorphic let binding.
@@ -222,9 +230,7 @@ module Constraint : sig
       bound to [x]. The variable [x] must be bound earlier by {!let_}. *)
   val inst : Var.t -> Type.t -> t
 
-  val over : Var.t list -> Type.t -> t
-  val let_implicit : Var.t -> in_:t -> t
-  val implicit : Type.t -> t
+  val implicit : Type.t -> in_:Implicit_scope.t -> t
 
   module Match_error : sig
     type t =

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -305,7 +305,54 @@ module Error : sig
         the given types [ty1] and [ty2]. *)
     | Cannot_discharge_match_constraints of Omniml_error.t list
     (** Some match constraints could not be discharged. *)
+    | Resolution_termination_check_failed
   [@@deriving sexp]
+end
+
+module Termination : sig
+  module Witness : sig
+    module Elab : Monad.S
+
+    (** A partial witness is a term of the form: 
+        {[ 
+           W ::= ? | s
+        ]} *)
+    type t
+
+    module Spine : sig
+      (** A witness spine is a partial term of the form: 
+          {[ 
+            s ::= x [tau1] ... [taun] W1 ... Wm
+          ]}
+
+          This represents a term inferred by an implicit hole.  *)
+      type witness := t
+
+      type t
+
+      val head : t -> Constraint.Var.t
+      val instantiation : t -> Decoded_type.t list Elab.t
+      val args : t -> witness list
+    end
+  end
+
+  module Check : sig
+    type t =
+      { recursive_occurrence_threshold : int
+        (** Number of recursive occurrences of the same variable 
+            after which we construct a candidate elaboration and 
+            run the termination checker. *)
+      ; rejects : Witness.t -> bool Witness.Elab.t
+        (** A predicate over candidate elaborations. 
+            
+            Returns [true] when the candidate exceeds the termination criterion. 
+
+            *Safety*: This function should be monotone with respect ot witnesses: 
+            If [rejects w] is true, then [rejects W[w]] is true where [W] is some 
+            one-hole witness context. *)
+      }
+    [@@deriving sexp_of]
+  end
 end
 
 (** [solve ?range c] solves the constraint [c]. 
@@ -317,5 +364,6 @@ end
 val solve
   :  ?range:Range.t
   -> ?defaulting:Omniml_options.Defaulting.t
+  -> ?termination_check:Termination.Check.t
   -> Constraint.t
   -> (unit, Error.t) result

--- a/lib/constraint_solver/omniml_constraint_solver.mli
+++ b/lib/constraint_solver/omniml_constraint_solver.mli
@@ -316,61 +316,24 @@ module Error : sig
 end
 
 module Termination : sig
-  module Witness : sig
-    module Elab : Monad.S
+  module Budget : sig
+    module Spec : sig
+      module type S = sig
+        (** [t] is the type of the budget*)
+        type t [@@deriving sexp_of, compare]
 
-    (** A partial witness is a term of the form: 
-        {[ 
-           W ::= ? | s
-        ]} *)
-    type t [@@deriving sexp_of]
+        val initial : t
+        val consume : Constraint.Var.t -> Decoded_type.t Lazy.t -> t -> t option
+      end
 
-    module Spine : sig
-      (** A witness spine is a partial term of the form: 
-          {[ 
-            s ::= x [tau1] ... [taun] W1 ... Wm
-          ]}
+      type t = (module S) [@@deriving sexp_of]
 
-          This represents a term inferred by an implicit hole.  *)
-      type witness := t
+      (** [unlimited] is a budget spec that consumes no budget. *)
+      val unlimited : t
 
-      type t [@@deriving sexp_of]
-
-      val head : t -> Constraint.Var.t
-      val instantiation : t -> Decoded_type.t list Elab.t
-      val args : t -> witness list
+      (** [bounded_by n] is a budget spec that consumes a simple counter. *)
+      val bounded_by : int -> t
     end
-
-    type view =
-      | Hole
-      | Spine of Spine.t
-    [@@deriving sexp_of]
-
-    val view : t -> view
-  end
-
-  module Check : sig
-    type t =
-      { recursive_occurrence_threshold : int
-        (** Number of recursive occurrences of the same variable 
-            after which we construct a candidate elaboration and 
-            run the termination checker. *)
-      ; rejects : Witness.t -> bool Witness.Elab.t
-        (** A predicate over candidate elaborations. 
-            
-            Returns [true] when the candidate exceeds the termination criterion. 
-
-            *Safety*: This function should be monotone with respect ot witnesses: 
-            If [rejects w] is true, then [rejects W[w]] is true where [W] is some 
-            one-hole witness context. *)
-      }
-    [@@deriving sexp_of]
-
-    (** [disabled] is a check that effectively acts as no termination check exists. *)
-    val disabled : t
-
-    (** [threshold n] is a check that fails when a given variable occurs recursively [>= n] times. *)
-    val threshold : int -> t
   end
 end
 
@@ -383,6 +346,6 @@ end
 val solve
   :  ?range:Range.t
   -> ?defaulting:Omniml_options.Defaulting.t
-  -> ?termination_check:Termination.Check.t
+  -> ?termination_budget_spec:Termination.Budget.Spec.t
   -> Constraint.t
   -> (unit, Error.t) result

--- a/lib/constraint_solver/principal_shape.ml
+++ b/lib/constraint_solver/principal_shape.ml
@@ -43,7 +43,7 @@ module Poly = struct
         let[@inline] num_uses (var : Type.Var.t) = uses.((var.id :> int)) in
         let[@inline] is_polyshape (shape : Self.t) =
           match shape with
-          | Sh_arrow | Sh_tuple _ | Sh_constr _ -> false
+          | Sh_arrow | Sh_implicit_arrow | Sh_tuple _ | Sh_constr _ -> false
           | Sh_poly _ -> true
         in
         (* We rely on non-short-circuting operators (since marking uses is effectful) *)
@@ -57,7 +57,7 @@ module Poly = struct
           | Var var ->
             mark_use var;
             Hash_set.mem scheme_quantifiers var
-          | Arrow (type1, type2) ->
+          | Arrow (type1, type2) | Implicit_arrow (type1, type2) ->
             (* Invariant: all constructors must contain a polymorphic subterm. *)
             assert (loop type1 ||| loop type2);
             true
@@ -95,6 +95,7 @@ end
 
 type t = Self.t =
   | Sh_arrow
+  | Sh_implicit_arrow
   | Sh_tuple of int
   | Sh_constr of int * Type.Ident.t
   | Sh_poly of Poly.t
@@ -112,14 +113,14 @@ let create_var ~id_source () = Type.Var.create ~id_source ~name:"Principal_shape
 
 let arity t =
   match t with
-  | Sh_arrow -> 2
+  | Sh_arrow | Sh_implicit_arrow -> 2
   | Sh_tuple n | Sh_constr (n, _) -> n
   | Sh_poly poly_shape -> List.length poly_shape.quantifiers
 ;;
 
 let quantifiers t =
   match t with
-  | Sh_arrow ->
+  | Sh_arrow | Sh_implicit_arrow ->
     (* Invariant: All quantifiers are locally named from 0 to n *)
     let id_source = Identifier.create_source () in
     (* [let]s are used to force the correct ordering *)
@@ -222,6 +223,10 @@ module Poly_shape_decomposition = struct
       (match types with
        | [ type1; type2 ] -> Arrow (type1, type2)
        | _ -> assert false)
+    | Sh_implicit_arrow ->
+      (match types with
+       | [ type1; type2 ] -> Implicit_arrow (type1, type2)
+       | _ -> assert false)
     | Sh_poly _ -> Shape (types, shape)
   ;;
 
@@ -244,6 +249,12 @@ module Poly_shape_decomposition = struct
         (self_with_original t2)
         ~state
         ~f:(fun t1 t2 -> Arrow (t1, t2))
+    | Implicit_arrow (t1, t2) ->
+      Part.map_principal_part2
+        (self_with_original t1)
+        (self_with_original t2)
+        ~state
+        ~f:(fun t1 t2 -> Implicit_arrow (t1, t2))
     | Tuple ts ->
       Part.map_principal_parts (List.map ts ~f:self_with_original) ~state ~f:(fun ts ->
         Tuple ts)

--- a/lib/constraint_solver/principal_shape.ml
+++ b/lib/constraint_solver/principal_shape.ml
@@ -302,7 +302,7 @@ module Var = struct
       { run : t -> unit
       ; default : unit -> unit
       ; cancel : unit -> unit
-      ; error : unit -> Omniml_error.t
+      ; error : unit -> Omniml_error.t option
       }
     [@@deriving sexp_of]
 
@@ -326,7 +326,10 @@ module Var = struct
     ;;
 
     let errors ts =
-      Doubly_linked.fold_right ts ~init:[] ~f:(fun t acc -> t.error () :: acc)
+      Doubly_linked.fold_right ts ~init:[] ~f:(fun t acc ->
+        match t.error () with
+        | None -> acc
+        | Some error -> error :: acc)
     ;;
   end
 

--- a/lib/constraint_solver/principal_shape.ml
+++ b/lib/constraint_solver/principal_shape.ml
@@ -301,6 +301,7 @@ module Var = struct
     type nonrec t =
       { run : t -> unit
       ; default : unit -> unit
+      ; cancel : unit -> unit
       ; error : unit -> Omniml_error.t
       }
     [@@deriving sexp_of]
@@ -310,25 +311,28 @@ module Var = struct
 
     let schedule_all ts shape =
       let scheduler = Scheduler.t () in
-      List.iter ts ~f:(fun t ->
+      Doubly_linked.iter ts ~f:(fun t ->
         let job = fun () -> t.run shape in
-        Scheduler.enqueue scheduler job)
+        Scheduler.enqueue scheduler job);
+      Doubly_linked.clear ts
     ;;
 
     let schedule_default_all ts =
       [%log.global.debug "Scheduling defaults"];
       let scheduler = Scheduler.t () in
-      List.iter ts ~f:(fun t ->
+      Doubly_linked.iter ts ~f:(fun t ->
         [%log.global.debug "Scheduling default"];
         Scheduler.enqueue scheduler t.default)
     ;;
 
-    let errors ts = List.map ts ~f:(fun t -> t.error ())
+    let errors ts =
+      Doubly_linked.fold_right ts ~init:[] ~f:(fun t acc -> t.error () :: acc)
+    ;;
   end
 
   module S = struct
     type desc =
-      | Empty of Handler.t list
+      | Empty of Handler.t Doubly_linked.t
       | Full of t
     [@@deriving sexp_of]
 
@@ -346,7 +350,9 @@ module Var = struct
 
     let merge_desc ~ctx:_ ~create:_ ~unify:_ ~type1:_ ~type2:_ t1 t2 =
       match t1, t2 with
-      | Empty hs1, Empty hs2 -> Empty (hs1 @ hs2)
+      | Empty hs1, Empty hs2 ->
+        Doubly_linked.transfer ~src:hs2 ~dst:hs1;
+        Empty hs1
       | Full s1, Full s2 -> if equal s1 s2 then Full s1 else raise Cannot_merge
       | Empty hs, Full s | Full s, Empty hs ->
         Handler.schedule_all hs s;
@@ -367,7 +373,7 @@ module Var = struct
       { id = Identifier.create id_source
       ; region
       ; guards = Guard_set.empty
-      ; desc = Empty []
+      ; desc = Empty (Doubly_linked.create ())
       }
     ;;
   end
@@ -392,10 +398,28 @@ module Var = struct
     | Full _ -> false
   ;;
 
+  module Registered_handler = struct
+    type t =
+      { wait_list : Handler.t Doubly_linked.t
+      ; handler : Handler.t Doubly_linked.Elt.t
+      }
+
+    let cancel_if_pending t =
+      if not (Doubly_linked.is_empty t.wait_list)
+      then (
+        (Doubly_linked.Elt.value t.handler).cancel ();
+        Doubly_linked.remove t.wait_list t.handler)
+    ;;
+  end
+
   let add_handler t handler =
     match desc t with
-    | Full s -> Handler.schedule handler s
-    | Empty handlers -> set_desc t (Empty (handler :: handlers))
+    | Full s ->
+      Handler.schedule handler s;
+      None
+    | Empty handlers ->
+      let handler = Doubly_linked.insert_first handlers handler in
+      Some { Registered_handler.wait_list = handlers; handler }
   ;;
 
   exception Empty

--- a/lib/constraint_solver/principal_shape.mli
+++ b/lib/constraint_solver/principal_shape.mli
@@ -34,11 +34,20 @@ module Var : sig
       { run : shape -> unit
         (** [run shape] runs the handler, where [shape] is the filled shape.  *)
       ; default : unit -> unit (** [default ()] is used to fill the variable (or fail). *)
+      ; cancel : unit -> unit (** [cancel ()] is used to cancel the handler. *)
       ; error : unit -> Omniml_error.t
         (** [error ()] is used to generate an error if the shape 
             variable cannot be defaulted. *)
       }
     [@@deriving sexp_of]
+  end
+
+  module Registered_handler : sig
+    type t
+
+    (** [cancel_if_pending t] removes the handler from its associated waitlist if 
+        it has not yet been scheduled. *)
+    val cancel_if_pending : t -> unit
   end
 
   (** A write-once cell containing a principal shape. *)
@@ -68,7 +77,7 @@ module Var : sig
   (** [add_handler t h] adds a handler to the shape var that is scheduled 
       once the variable is filled. If the shape is already filled, then 
       the handler is scheduled immediately. *)
-  val add_handler : t -> Handler.t -> unit
+  val add_handler : t -> Handler.t -> Registered_handler.t option
 
   exception Empty
 

--- a/lib/constraint_solver/principal_shape.mli
+++ b/lib/constraint_solver/principal_shape.mli
@@ -35,9 +35,10 @@ module Var : sig
         (** [run shape] runs the handler, where [shape] is the filled shape.  *)
       ; default : unit -> unit (** [default ()] is used to fill the variable (or fail). *)
       ; cancel : unit -> unit (** [cancel ()] is used to cancel the handler. *)
-      ; error : unit -> Omniml_error.t
+      ; error : unit -> Omniml_error.t option
         (** [error ()] is used to generate an error if the shape 
-            variable cannot be defaulted. *)
+            variable cannot be defaulted. The error is optional 
+            (if the handler is silent) *)
       }
     [@@deriving sexp_of]
   end

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -27,6 +27,7 @@ module Env = struct
   type t =
     { type_vars : G.Type.t Type.Var.Map.t
     ; expr_vars : G.Scheme.t Constraint.Var.Map.t
+    ; implicit_vars : Constraint.Var.Set.t
     ; curr_region : G.Region.t
     ; range : Range.t option
     }
@@ -38,6 +39,7 @@ module Env = struct
   let empty ~range ~curr_region =
     { type_vars = Type.Var.Map.empty
     ; expr_vars = Constraint.Var.Map.empty
+    ; implicit_vars = Constraint.Var.Set.empty
     ; curr_region
     ; range
     }
@@ -50,6 +52,8 @@ module Env = struct
   let bind_var t ~var ~type_ =
     { t with expr_vars = Map.set t.expr_vars ~key:var ~data:type_ }
   ;;
+
+  let add_implicit_var t var = { t with implicit_vars = Set.add t.implicit_vars var }
 
   let find_type_var t type_var =
     try Map.find_exn t.type_vars type_var with
@@ -69,7 +73,9 @@ module Env = struct
     }
   ;;
 
-  let create_scheme t root = G.create_scheme ~curr_region:t.curr_region root
+  let create_scheme t ?implicits root =
+    G.create_scheme ~curr_region:t.curr_region ?implicits root
+  ;;
 
   let of_gclosure
         (gclosure : G.Suspended_match.closure)
@@ -170,57 +176,59 @@ let match_type
   | Sh_poly poly_shape -> env, Poly poly_shape.scheme
 ;;
 
-module Over_switch = struct
-  type t = { mutable remaining_overs : over Constraint.Var.Map.t }
+module Overload = struct
+  module Switch = struct
+    type t = { mutable remaining_overs : over Constraint.Var.Map.t }
 
-  and over =
-    { mutable over_handlers : Principal_shape.Var.Registered_handler.t list
-    ; over_scheme : G.Scheme.t
-    }
+    and over =
+      { mutable over_handlers :
+          (Principal_shape.Var.Registered_handler.t list[@sexp.opaque])
+      ; over_scheme : G.Scheme.t
+      }
+    [@@deriving sexp_of]
 
-  let create initial_overs =
-    { remaining_overs =
-        initial_overs
-        |> List.map ~f:(fun (over_var, over_scheme) ->
-          over_var, { over_scheme; over_handlers = [] })
-        |> Constraint.Var.Map.of_alist_exn
-    }
-  ;;
+    let create initial_overs =
+      { remaining_overs =
+          initial_overs
+          |> List.map ~f:(fun (over_var, over_scheme) ->
+            over_var, { over_scheme; over_handlers = [] })
+          |> Constraint.Var.Map.of_alist_exn
+      }
+    ;;
 
-  let remove_over t over =
-    Map.find t.remaining_overs over
-    |> Option.iter ~f:(fun { over_handlers; over_scheme = _ } ->
-      List.iter over_handlers ~f:Principal_shape.Var.Registered_handler.cancel_if_pending;
-      t.remaining_overs <- Map.remove t.remaining_overs over)
-  ;;
+    let remove_over t over =
+      Map.find t.remaining_overs over
+      |> Option.iter ~f:(fun { over_handlers; over_scheme = _ } ->
+        List.iter
+          over_handlers
+          ~f:Principal_shape.Var.Registered_handler.cancel_if_pending;
+        t.remaining_overs <- Map.remove t.remaining_overs over)
+    ;;
+  end
 
-  let ambiguous t = Map.length t.remaining_overs > 1
+  let is_ambiguous ~(switch : Switch.t) = Map.length switch.remaining_overs > 1
 
-  let unify_if_unique ~(state : State.t) ~(env : Env.t) t expected_type =
-    if ambiguous t
+  let if_unique ~(switch : Switch.t) ~do_ =
+    if is_ambiguous ~switch
     then ()
     else (
-      match Map.to_alist t.remaining_overs with
-      | [ (_over_var, over) ] ->
-        let actual_gtype =
-          G.instantiate ~state ~curr_region:env.curr_region over.over_scheme
-        in
-        unify ~state ~env actual_gtype expected_type
+      match Map.to_alist switch.remaining_overs with
+      | [ (_over_var, over) ] -> do_ over.over_scheme
       | _ -> assert false)
   ;;
 
-  let over_match
+  let match_
         ~(state : State.t)
         ~(env : Env.t)
+        ~(switch : Switch.t)
         ~curr_region
-        t
         ~over
         matchee
         ~closure
         ~with_
     =
     let range = Option.value_exn ~here:[%here] env.range in
-    match Map.find t.remaining_overs over with
+    match Map.find switch.remaining_overs over with
     | None ->
       (* overload was already removed, no need to generate any subsequent constraints *)
       ()
@@ -249,21 +257,24 @@ module Over_switch = struct
   let rec filter_over
             ~(state : State.t)
             ~(env : Env.t)
-            t
-            ~expected_type
+            ~(switch : Switch.t)
+            ~with_
+            ~closure
             ~over
             over_type_p
             expected_type_p
     =
-    over_match
+    match_
       ~state
       ~env
+      ~switch
       ~curr_region:`Env
-      t
       ~over
       expected_type_p
-      ~closure:[ expected_type ]
+      ~closure
       ~with_:(fun ~shape:expected_type_p_shape ~args:expected_type_p_args ->
+        (* If the current type in the overloaded scheme is generic and a variable, 
+           then don't register a match constraint on it *)
         if
           G.Type.is_generic over_type_p
           &&
@@ -272,14 +283,14 @@ module Over_switch = struct
           | _ -> false
         then ()
         else
-          over_match
+          match_
             ~state
             ~env
+            ~switch
             ~curr_region:`Over
-            t
             ~over
             over_type_p
-            ~closure:([ expected_type ] @ expected_type_p_args)
+            ~closure:(closure @ expected_type_p_args)
             ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
               if Principal_shape.equal expected_type_p_shape over_type_p_shape
               then
@@ -290,37 +301,74 @@ module Over_switch = struct
                     filter_over
                       ~state
                       ~env
-                      t
-                      ~expected_type
+                      ~switch
+                      ~closure
+                      ~with_
                       ~over
                       over_type_p_arg
                       expected_type_p_arg)
               else (
-                remove_over t over;
-                unify_if_unique ~state ~env t expected_type)))
+                Switch.remove_over switch over;
+                if_unique ~switch ~do_:with_)))
   ;;
 
-  let match_ ~state ~env t ~expected_type =
+  let match_ ~state ~env expected_type ~in_:overloads ~closure ~with_ =
+    let switch = Switch.create overloads in
     Map.iteri
-      t.remaining_overs
+      switch.remaining_overs
       ~f:(fun ~key:over ~data:{ over_scheme; over_handlers = _ } ->
-        filter_over ~state ~env t ~expected_type ~over over_scheme.root expected_type)
+        filter_over
+          ~state
+          ~env
+          ~switch
+          ~closure
+          ~with_
+          ~over
+          over_scheme.root
+          expected_type)
   ;;
 end
+
+let rec implicit_instantiate ~(state : State.t) ~(env : Env.t) gscheme expected_type =
+  let implicits, actual_type =
+    G.instantiate ~state ~curr_region:env.curr_region gscheme
+  in
+  unify ~state ~env actual_type expected_type;
+  match implicits with
+  | [] ->
+    (* Optimize for the common case *)
+    ()
+  | _ ->
+    let env_implicits =
+      env.implicit_vars
+      |> Set.to_list
+      |> List.map ~f:(fun var -> var, Env.find_var env var)
+    in
+    List.iter implicits ~f:(over_instantiate ~state ~env ~in_:env_implicits)
+
+and over_instantiate ~state ~env expected_type ~in_ =
+  Overload.match_
+    ~state
+    ~env
+    expected_type
+    ~in_
+    ~closure:[ expected_type ]
+    ~with_:(fun gscheme -> implicit_instantiate ~state ~env gscheme expected_type)
+;;
 
 let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
   fun ~state ~env cst ->
   [%log.global.debug
     "Solving constraint" (state : State.t) (env : Env.t) (cst : Constraint.t)];
-  let self ~state ?(env = env) cst = solve ~state ~env cst in
+  let self ~state ~env cst = solve ~state ~env cst in
   match cst with
   | True -> ()
   | False err -> Env.raise env @@ Unsatisfiable err
   | Conj (cst1, cst2) ->
     [%log.global.debug "Solving conj lhs"];
-    self ~state cst1;
+    self ~state ~env cst1;
     [%log.global.debug "Solving conj rhs"];
-    self ~state cst2
+    self ~state ~env cst2
   | Eq (type1, type2) ->
     [%log.global.debug "Decoding type1" (type1 : Type.t)];
     let gtype1 = gtype_of_type ~state ~env type1 in
@@ -345,16 +393,13 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     let var_gscheme = Env.find_var env var in
     [%log.global.debug
       "Instantiating scheme" (var : Constraint.Var.t) (var_gscheme : G.Scheme.t)];
-    let actual_gtype = G.instantiate ~state ~curr_region:env.curr_region var_gscheme in
-    [%log.global.debug "Scheme instance" (actual_gtype : G.Type.t)];
-    unify ~state ~env actual_gtype expected_gtype
+    implicit_instantiate ~state ~env var_gscheme expected_gtype
   | Over_instance (vars, expected_type) ->
     [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
     let expected_gtype = gtype_of_type ~state ~env expected_type in
     [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
     let overs = List.map vars ~f:(fun over_var -> over_var, Env.find_var env over_var) in
-    let switch = Over_switch.create overs in
-    Over_switch.match_ ~state ~env switch ~expected_type:expected_gtype
+    over_instantiate ~state ~env expected_gtype ~in_:overs
   | Exists (type_var, cst) ->
     [%log.global.debug "Binding unification for type_var" (type_var : Type.Var.t)];
     let env = exists ~state ~env ~type_var in
@@ -402,9 +447,22 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
         { matchee = gmatchee; closure = gclosure; case; else_; error }
     in
     ()
+  | Let_implicit (var_name, in_) ->
+    let env = Env.add_implicit_var env var_name in
+    self ~state ~env in_
+  | Implicit expected_type ->
+    [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
+    let expected_gtype = gtype_of_type ~state ~env expected_type in
+    [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
+    let env_implicits =
+      env.implicit_vars
+      |> Set.to_list
+      |> List.map ~f:(fun var -> var, Env.find_var env var)
+    in
+    over_instantiate ~state ~env expected_gtype ~in_:env_implicits
   | With_range (t, range) -> solve ~state ~env:(Env.with_range env ~range) t
 
-and solve_let_binding ~state ~env { type_vars; in_; bindings } =
+and solve_let_binding ~state ~env { type_vars; implicits; in_; bindings } =
   let env = Env.enter_new_region ~state env in
   [%log.global.debug "Entered new region" (env : Env.t)];
   let env =
@@ -419,6 +477,9 @@ and solve_let_binding ~state ~env { type_vars; in_; bindings } =
       (env : Env.t)];
   [%log.global.debug "Solving scheme's constraint"];
   solve ~state ~env in_;
+  let gimplicits =
+    List.map implicits ~f:(fun implicit -> gtype_of_type ~state ~env implicit)
+  in
   let gbindings =
     List.map bindings ~f:(fun { binding_var; binding_type } ->
       [%log.global.debug
@@ -426,7 +487,7 @@ and solve_let_binding ~state ~env { type_vars; in_; bindings } =
       let binding_gtype = gtype_of_type ~state ~env binding_type in
       [%log.global.debug
         "Type of binding" (binding_var : Constraint.Var.t) (binding_gtype : G.Type.t)];
-      let gscheme = Env.create_scheme env binding_gtype in
+      let gscheme = Env.create_scheme env ~implicits:gimplicits binding_gtype in
       binding_var, gscheme)
   in
   [%log.global.debug "Bindings" (gbindings : (Constraint.Var.t * G.Scheme.t) list)];

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -34,6 +34,8 @@ module Termination = struct
       { seen = Map.update t.seen var ~f:(Option.value_map ~default:1 ~f:Int.succ) }
     ;;
 
+    let reset t var = { seen = Map.set t.seen ~key:var ~data:0 }
+
     let count t var =
       try Map.find_exn t.seen var with
       | _ -> 0
@@ -83,7 +85,10 @@ module Termination = struct
       let args t = t.args
     end
 
-    type view = desc
+    type view = desc =
+      | Hole
+      | Spine of spine
+    [@@deriving sexp_of]
 
     let view (t : t) = !t
     let hole () = ref Hole
@@ -107,8 +112,14 @@ module Termination = struct
       else `No_check
     ;;
 
-    let default =
-      { recursive_occurrence_threshold = 256
+    let disabled =
+      { recursive_occurrence_threshold = Int.max_value
+      ; rejects = (fun _ -> Witness.Elab.return false)
+      }
+    ;;
+
+    let threshold n =
+      { recursive_occurrence_threshold = n
       ; rejects = (fun _ -> Witness.Elab.return true)
       }
     ;;
@@ -153,6 +164,10 @@ module Env = struct
 
   let mark_var_in_termination_history t var =
     { t with termination_history = Termination.History.mark t.termination_history var }
+  ;;
+
+  let reset_var_in_termination_history t var =
+    { t with termination_history = Termination.History.reset t.termination_history var }
   ;;
 
   let find_type_var t type_var =
@@ -518,16 +533,22 @@ let rec resolve_implicit
             Spine (Spine.create ~head ~instantiation ~args:implicit_witnesses)));
       (* Mark the variable in the history *)
       let env = Env.mark_var_in_termination_history env head in
-      (match
-         Termination.Check.check_if_exceeded_threshold
-           env.termination_check
-           env.termination_history
-           ~on:head
-           ~root_witness
-       with
-       | `No_check -> ()
-       | `Check rejects ->
-         if rejects then Env.raise env Resolution_termination_check_failed);
+      let env =
+        match
+          Termination.Check.check_if_exceeded_threshold
+            env.termination_check
+            env.termination_history
+            ~on:head
+            ~root_witness
+        with
+        | `No_check -> env
+        | `Check rejects ->
+          if rejects
+          then Env.raise env Resolution_termination_check_failed
+          else
+            (* TODO: Reset globally instead of just in current path *)
+            Env.reset_var_in_termination_history env head
+      in
       (* Safety: List.length implicit_witnesses = List.length implicits by construction *)
       List.iter2_exn implicits implicit_witnesses ~f:(fun implicit implicit_witness ->
         resolve_implicit
@@ -722,10 +743,7 @@ let solve
   -> Constraint.t
   -> (unit, Error.t) result
   =
-  fun ?range ?defaulting ?termination_check cst ->
-  let termination_check =
-    Option.value termination_check ~default:Termination.Check.default
-  in
+  fun ?range ?defaulting ?(termination_check = Termination.Check.disabled) cst ->
   try
     Scheduler.(clear (t ()));
     let state = State.create ?defaulting () in

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -20,8 +20,8 @@ module Error = struct
 
   exception T of t
 
-  let create ~range it = { it; range }
-  let raise ~range it = raise @@ T { it; range }
+  let create ?range it = { it; range }
+  let raise ?range it = raise @@ T { it; range }
 end
 
 module Termination = struct
@@ -120,7 +120,7 @@ module Termination = struct
           let budget = interpret budget_term in
           (match Tbs.consume var (decode_type type_) budget with
            | Some budget -> budget
-           | None -> Error.(raise ~range @@ Resolution_termination_check_failed))
+           | None -> Error.(raise ?range @@ Resolution_termination_check_failed))
       in
       ignore (interpret budget : Tbs.t)
     ;;
@@ -140,7 +140,6 @@ module Env = struct
   type t =
     { type_vars : G.Type.t Type.Var.Map.t
     ; expr_vars : G.Scheme.t Constraint.Var.Map.t
-    ; implicit_vars : Constraint.Var.Set.t
     ; curr_region : G.Region.t
     ; range : Range.t option
     ; termination_check : Termination.Check.t
@@ -148,13 +147,12 @@ module Env = struct
     }
   [@@deriving sexp_of]
 
-  let raise t err = Error.raise ~range:t.range err
+  let raise t err = Error.raise ?range:t.range err
   let with_range t ~range = { t with range = Some range }
 
   let empty ~range ~curr_region ~termination_check =
     { type_vars = Type.Var.Map.empty
     ; expr_vars = Constraint.Var.Map.empty
-    ; implicit_vars = Constraint.Var.Set.empty
     ; curr_region
     ; range
     ; termination_check
@@ -169,8 +167,6 @@ module Env = struct
   let bind_var t ~var ~type_ =
     { t with expr_vars = Map.set t.expr_vars ~key:var ~data:type_ }
   ;;
-
-  let add_implicit_var t var = { t with implicit_vars = Set.add t.implicit_vars var }
 
   let increase_termination_pressure t var =
     { t with
@@ -203,9 +199,7 @@ module Env = struct
     }
   ;;
 
-  let create_scheme t ?implicits root =
-    G.create_scheme ~curr_region:t.curr_region ?implicits root
-  ;;
+  let create_scheme t root = G.create_scheme ~curr_region:t.curr_region root
 
   let of_gclosure
         (gclosure : G.Suspended_match.closure)
@@ -228,10 +222,6 @@ module Env = struct
     | None -> t.curr_region
     | Some parent -> parent
   ;;
-
-  let implicit_env t =
-    t.implicit_vars |> Set.to_list |> List.map ~f:(fun var -> var, find_var t var)
-  ;;
 end
 
 let rec gtype_of_type : state:State.t -> env:Env.t -> Type.t -> G.Type.t =
@@ -244,6 +234,7 @@ let rec gtype_of_type : state:State.t -> env:Env.t -> Type.t -> G.Type.t =
   match type_ with
   | Var type_var -> Env.find_type_var env type_var
   | Arrow (t1, t2) -> gformer ~env [ self t1; self t2 ] Sh_arrow
+  | Implicit_arrow (t1, t2) -> gformer ~env [ self t1; self t2 ] Sh_implicit_arrow
   | Tuple ts -> gformer ~env (List.map ~f:self ts) (Sh_tuple (List.length ts))
   | Constr (ts, ident) ->
     gformer ~env (List.map ~f:self ts) (Sh_constr (List.length ts, ident))
@@ -306,232 +297,390 @@ let match_type
     (match shape_quantifiers with
      | [ var1; var2 ] -> env, Arrow (var1, var2)
      | _ -> assert false)
+  | Sh_implicit_arrow ->
+    (match shape_quantifiers with
+     | [ var1; var2 ] -> env, Implicit_arrow (var1, var2)
+     | _ -> assert false)
   | Sh_tuple _n -> env, Tuple shape_quantifiers
   | Sh_constr (_n, ident) -> env, Constr (shape_quantifiers, ident)
   | Sh_poly poly_shape -> env, Poly poly_shape.scheme
 ;;
 
-module Overload = struct
-  module Switch : sig
-    type t [@@deriving sexp_of]
+module Implicit_resolution = struct
+  (* Implicit resolution via multi-stage filtering:
 
-    val create : (Constraint.Var.t * G.Scheme.t) list -> t
+     Stage 1: Strip implicit parameter types from expected type and all candidates,
+              tracking the spine depth (number of implicit arrows stripped)
+     Stage 2: Eliminate candidates by comparing simple shapes (non-implicit-arrow shapes)
 
-    val match_
-      :  state:State.t
-      -> env:Env.t
-      -> in_:t
-      -> curr_region:[ `Env | `Over ]
-      -> over:Constraint.Var.t
-      -> G.Type.t
-      -> closure:G.Type.t list
-      -> with_:(shape:Principal_shape.t -> args:G.Type.t list -> unit)
-      -> unit
+     A simple shape is any shape that is not Sh_implicit_arrow.
 
-    val remove : t -> Constraint.Var.t -> unit
+     The spine depth tracks:
+     - For expected type: number of implicit arrows stripped
+     - For each candidate: difference in implicit arrow count (for eta-expansion/holes)
+  *)
 
-    exception Not_resolved
-
-    val try_resolve : t -> f:(Constraint.Var.t -> G.Scheme.t -> 'a) -> 'a
-    val iter : t -> f:(key:Constraint.Var.t -> data:G.Scheme.t -> unit) -> unit
-  end = struct
+  (** Shared error state for implicit resolution.
+      Ensures only a single error is raised even when multiple match operations fail. *)
+  module Error_switch = struct
     type t =
-      { mutable remaining_overs : over Constraint.Var.Map.t
-      ; mutable has_raised_error : bool
+      { mutable has_raised_error : bool
+      ; range : Range.t
       }
 
-    and over =
-      { mutable over_handlers :
-          (Principal_shape.Var.Registered_handler.t list[@sexp.opaque])
-      ; over_scheme : G.Scheme.t
-      }
-    [@@deriving sexp_of]
+    let create ~range = { has_raised_error = false; range }
+    let omniml_error t = Omniml_error.ambiguous_overloading ~range:t.range
 
-    let add_handler_over over handler =
-      over.over_handlers <- handler :: over.over_handlers
+    let raise t () =
+      t.has_raised_error <- true;
+      Error.raise ~range:t.range @@ Unsatisfiable (omniml_error t)
     ;;
 
-    let cancel_over over =
-      List.iter
-        over.over_handlers
-        ~f:Principal_shape.Var.Registered_handler.cancel_if_pending
-    ;;
-
-    let error t ~range =
+    let omniml_error_if_not_raised t =
       if t.has_raised_error
       then None
       else (
         t.has_raised_error <- true;
-        Some Omniml_error.(ambiguous_overloading ~range))
+        Some (omniml_error t))
     ;;
 
-    let create initial_overs =
-      { remaining_overs =
-          initial_overs
-          |> List.map ~f:(fun (over_var, over_scheme) ->
-            over_var, { over_scheme; over_handlers = [] })
-          |> Constraint.Var.Map.of_alist_exn
-      ; has_raised_error = false
-      }
+    let match_error t : Constraint.Match_error.t -> Omniml_error.t option = function
+      | Inconsistent_default _ -> assert false
+      | Cannot_default | Matchee_is_rigid -> omniml_error_if_not_raised t
     ;;
 
-    let remove t over_var =
-      Map.find t.remaining_overs over_var
-      |> Option.iter ~f:(fun over ->
-        cancel_over over;
-        t.remaining_overs <- Map.remove t.remaining_overs over_var)
+    let match_ t ~state ~curr_region matchee ~closure ~with_ =
+      G.Suspended_match.match_or_yield
+        ~state
+        ~curr_region
+        { matchee; closure; case = with_; else_ = raise t; error = match_error t }
+    ;;
+  end
+
+  module Filter_switch : sig
+    type 'a t [@@deriving sexp_of]
+
+    val create : (Constraint.Var.t * 'a) list -> 'a t
+    val remove : 'a t -> Constraint.Var.t -> unit
+    val mem : 'a t -> Constraint.Var.t -> bool
+
+    val add_handler
+      :  'a t
+      -> Constraint.Var.t
+      -> Principal_shape.Var.Registered_handler.t
+      -> unit
+
+    exception Not_resolved
+
+    val try_resolve : 'a t -> f:(Constraint.Var.t -> 'a -> 'b) -> 'b
+  end = struct
+    module Candidate = struct
+      type 'a t =
+        { it : 'a
+        ; mutable handlers : (Principal_shape.Var.Registered_handler.t list[@sexp.opaque])
+        }
+      [@@deriving sexp_of]
+
+      let create it = { it; handlers = [] }
+      let add_handler t handler = t.handlers <- handler :: t.handlers
+
+      let cancel_handlers t =
+        List.iter t.handlers ~f:Principal_shape.Var.Registered_handler.cancel_if_pending
+      ;;
+    end
+
+    type 'a t = { remaining_candidates : (Constraint.Var.t, 'a Candidate.t) Hashtbl.t }
+    [@@deriving sexp_of]
+
+    let create candidates =
+      let candidates =
+        List.map candidates ~f:(fun (var, it) -> var, Candidate.create it)
+        |> Hashtbl.of_alist_exn (module Constraint.Var)
+      in
+      assert (Hashtbl.length candidates >= 2);
+      { remaining_candidates = candidates }
+    ;;
+
+    let add_handler t candidate_var handler =
+      let candidate = Hashtbl.find_exn t.remaining_candidates candidate_var in
+      Candidate.add_handler candidate handler
+    ;;
+
+    let mem t candidate_var = Hashtbl.mem t.remaining_candidates candidate_var
+
+    let remove t candidate_var =
+      Hashtbl.find_and_remove t.remaining_candidates candidate_var
+      |> Option.iter ~f:Candidate.cancel_handlers
     ;;
 
     exception Not_resolved
 
     let try_resolve t ~f =
-      if Map.length t.remaining_overs <> 1
+      if Hashtbl.length t.remaining_candidates <> 1
       then raise Not_resolved
       else (
-        match Map.to_alist t.remaining_overs with
-        | [ (over_var, over) ] ->
-          cancel_over over;
-          f over_var over.over_scheme
+        match Hashtbl.to_alist t.remaining_candidates with
+        | [ (candidate_var, candidate) ] ->
+          Candidate.cancel_handlers candidate;
+          f candidate_var candidate.it
         | _ -> assert false)
-    ;;
-
-    let match_
-          ~(state : State.t)
-          ~(env : Env.t)
-          ~(in_ : t)
-          ~curr_region
-          ~over
-          matchee
-          ~closure
-          ~with_
-      =
-      let range = Option.value_exn ~here:[%here] env.range in
-      match Map.find in_.remaining_overs over with
-      | None ->
-        (* overload was already removed, no need to generate any subsequent constraints *)
-        ()
-      | Some over ->
-        let curr_region =
-          match curr_region with
-          | `Env -> env.curr_region
-          | `Over -> over.over_scheme.region
-        in
-        G.Suspended_match.match_or_yield
-          ~state
-          ~curr_region
-          { matchee
-          ; closure = { variables = closure; schemes = [ over.over_scheme ] }
-          ; case = with_
-          ; else_ = (fun () -> Omniml_error.(raise @@ ambiguous_overloading ~range))
-          ; error =
-              (function
-                | Cannot_default -> error in_ ~range
-                | Inconsistent_default _ -> assert false
-                | Matchee_is_rigid -> Some Omniml_error.(ambiguous_overloading ~range))
-          }
-        |> Option.iter ~f:(add_handler_over over)
-    ;;
-
-    let iter t ~f =
-      Map.iteri t.remaining_overs ~f:(fun ~key ~data:over ->
-        f ~key ~data:over.over_scheme)
     ;;
   end
 
-  let rec filter_over
+  let match_possibly_generic ~error_switch ~state ~curr_region matchee ~closure ~with_ =
+    if
+      G.Type.is_generic matchee
+      &&
+      match G.Type.inner matchee with
+      | Var -> true
+      | _ -> false
+    then None
+    else Error_switch.match_ error_switch ~state ~curr_region matchee ~closure ~with_
+  ;;
+
+  let strip_implicits
+        ~(state : State.t)
+        ~(error_switch : Error_switch.t)
+        ~curr_region
+        (type_ : G.Type.t)
+        ~closure
+        ~(with_ : spine:int -> ret:G.Type.t -> unit)
+    : unit
+    =
+    let rec loop type_ ~spine =
+      match_possibly_generic
+        ~error_switch
+        ~state
+        ~curr_region
+        type_
+        ~closure
+        ~with_:(fun ~shape ~args ->
+          match shape with
+          | Sh_implicit_arrow ->
+            (match args with
+             | [ _implicit_param; result_type ] -> loop result_type ~spine:(spine + 1)
+             | _ -> assert false)
+          | _simple_shape -> with_ ~spine ~ret:type_)
+      |> ignore
+    in
+    loop type_ ~spine:0
+  ;;
+
+  let candidate_match
+        ~(state : State.t)
+        ~(error_switch : Error_switch.t)
+        ~(filter_switch : 'a Filter_switch.t)
+        ~curr_region
+        ~candidate
+        matchee
+        ~closure
+        ~with_
+    =
+    if Filter_switch.mem filter_switch candidate
+    then
+      match_possibly_generic ~error_switch ~state ~curr_region matchee ~closure ~with_
+      |> Option.iter ~f:(Filter_switch.add_handler filter_switch candidate)
+  ;;
+
+  let remove_and_try_resolve ~filter_switch candidate ~with_ =
+    Filter_switch.remove filter_switch candidate;
+    try Filter_switch.try_resolve filter_switch ~f:with_ with
+    | Filter_switch.Not_resolved -> ()
+  ;;
+
+  let rec filter_by_shape
             ~(state : State.t)
             ~(env : Env.t)
-            ~(switch : Switch.t)
-            ~with_
-            ~closure
-            ~over
-            over_type_p
+            ~error_switch
+            ~filter_switch
+            ~candidate
+            ~candidate_region
             expected_type_p
+            candidate_type_p
+            ~closure
+            ~with_
     =
-    Switch.match_
+    candidate_match
       ~state
-      ~env
-      ~in_:switch
-      ~curr_region:`Env
-      ~over
+      ~error_switch
+      ~filter_switch
+      ~curr_region:env.curr_region
+      ~candidate
       expected_type_p
       ~closure
       ~with_:(fun ~shape:expected_type_p_shape ~args:expected_type_p_args ->
-        (* If the current type in the overloaded scheme is generic and a variable, 
-           then don't register a match constraint on it *)
-        if
-          G.Type.is_generic over_type_p
-          &&
-          match G.Type.inner over_type_p with
-          | Var -> true
-          | _ -> false
-        then ()
-        else
-          Switch.match_
+        candidate_match
+          ~state
+          ~error_switch
+          ~filter_switch
+          ~curr_region:candidate_region
+          ~candidate
+          candidate_type_p
+          ~closure:{ closure with variables = expected_type_p_args @ closure.variables }
+          ~with_:(fun ~shape:candidate_type_p_shape ~args:candidate_type_p_args ->
+            compare_shapes_and_filter
+              ~state
+              ~env
+              ~error_switch
+              ~filter_switch
+              ~candidate
+              ~candidate_region
+              expected_type_p_shape
+              expected_type_p_args
+              candidate_type_p_shape
+              candidate_type_p_args
+              ~with_
+              ~closure))
+
+  and compare_shapes_and_filter
+        ~(state : State.t)
+        ~(env : Env.t)
+        ~error_switch
+        ~filter_switch
+        ~candidate
+        ~candidate_region
+        expected_type_p_shape
+        expected_type_p_args
+        candidate_type_p_shape
+        candidate_type_p_args
+        ~closure
+        ~with_
+    =
+    if Principal_shape.equal expected_type_p_shape candidate_type_p_shape
+    then
+      List.iter2_exn
+        expected_type_p_args
+        candidate_type_p_args
+        ~f:(fun expected_arg over_arg ->
+          filter_by_shape
             ~state
             ~env
-            ~in_:switch
-            ~curr_region:`Over
-            ~over
-            over_type_p
-            ~closure:(closure @ expected_type_p_args)
-            ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
-              if Principal_shape.equal expected_type_p_shape over_type_p_shape
-              then
-                List.iter2_exn
-                  expected_type_p_args
-                  over_type_p_args
-                  ~f:(fun expected_type_p_arg over_type_p_arg ->
-                    filter_over
-                      ~state
-                      ~env
-                      ~switch
-                      ~closure
-                      ~with_
-                      ~over
-                      over_type_p_arg
-                      expected_type_p_arg)
-              else (
-                Switch.remove switch over;
-                try Switch.try_resolve switch ~f:with_ with
-                | Switch.Not_resolved -> ())))
+            ~error_switch
+            ~filter_switch
+            ~candidate
+            ~candidate_region
+            expected_arg
+            over_arg
+            ~with_
+            ~closure)
+    else remove_and_try_resolve ~filter_switch candidate ~with_
   ;;
 
-  let match_ ~state ~env expected_type ~in_:overloads ~closure ~with_ =
-    let switch = Switch.create overloads in
-    try Switch.try_resolve switch ~f:with_ with
-    | Switch.Not_resolved ->
-      Switch.iter switch ~f:(fun ~key:over ~data:over_scheme ->
-        filter_over
-          ~state
-          ~env
-          ~switch
-          ~closure
-          ~with_
-          ~over
-          over_scheme.root
-          expected_type)
+  let match_ ~(state : State.t) ~(env : Env.t) ~candidates expected_type ~with_ =
+    let error_switch =
+      Error_switch.create ~range:(Option.value_exn ~here:[%here] env.range)
+    in
+    let closure : G.Suspended_match.closure =
+      { variables = [ expected_type ]; schemes = List.map ~f:snd candidates }
+    in
+    let strip_implicits_for_candidates candidates ~with_ =
+      let rec loop acc = function
+        | [] -> with_ (List.rev acc)
+        | (candidate_var, candidate_scheme) :: candidates ->
+          strip_implicits
+            ~state
+            ~error_switch
+            ~curr_region:candidate_scheme.G.Scheme.region
+            candidate_scheme.root
+            ~closure
+            ~with_:(fun ~spine ~ret ->
+              loop ((candidate_var, candidate_scheme, spine, ret) :: acc) candidates)
+      in
+      loop [] candidates
+    in
+    (* Step 1: Obtain the spine lengths of all implicit arrows. *)
+    strip_implicits
+      ~state
+      ~error_switch
+      ~curr_region:env.curr_region
+      expected_type
+      ~closure
+      ~with_:(fun ~spine:expected_spine ~ret:expected_type_ret ->
+        let with_ candidate_var (candidate_scheme, candidate_spine) =
+          if candidate_spine < expected_spine
+          then Error_switch.raise error_switch ()
+          else
+            with_
+              candidate_var
+              ~implicit_spine:(expected_spine - candidate_spine)
+              candidate_scheme
+        in
+        strip_implicits_for_candidates
+          candidates
+          ~with_:(fun candidates_with_spine_rets ->
+            match candidates_with_spine_rets with
+            | [] -> Error_switch.raise error_switch ()
+            | [ (candidate_var, candidate_scheme, candidate_spine, _candidate_type_ret) ]
+              ->
+              (* Edge case: Only one candidate, solve immediately *)
+              with_ candidate_var (candidate_scheme, candidate_spine)
+            | candidates_with_spine_rets ->
+              let filter_switch =
+                candidates_with_spine_rets
+                |> List.map ~f:(fun (x, scm, spine, _ret) -> x, (scm, spine))
+                |> Filter_switch.create
+              in
+              (* Step 2: Filter the candidates by the return types. *)
+              List.iter
+                candidates_with_spine_rets
+                ~f:
+                  (fun
+                    (candidate_var, candidate_scheme, _candidate_spine, candidate_type_ret)
+                  ->
+                  filter_by_shape
+                    ~state
+                    ~env
+                    ~error_switch
+                    ~filter_switch
+                    ~candidate:candidate_var
+                    ~candidate_region:candidate_scheme.G.Scheme.region
+                    expected_type_ret
+                    candidate_type_ret
+                    ~closure
+                    ~with_)))
   ;;
 end
 
 let instantiate ~(state : State.t) ~(env : Env.t) gscheme expected_type =
-  let instantiation, implicits, actual_type =
+  let instantiation, actual_type =
     G.instantiate ~state ~curr_region:env.curr_region gscheme
   in
   unify ~state ~env actual_type expected_type;
-  instantiation, implicits
+  instantiation
 ;;
 
-let rec resolve_implicit ~state ~env ~termination_budget ~implicit_env expected_type =
-  Overload.match_
+let rec resolve_implicit
+          ~state
+          ~env
+          ~termination_budget
+          ~implicit_scope
+          (expected_type : G.Type.t)
+  =
+  Implicit_resolution.match_
     ~state
     ~env
+    ~candidates:implicit_scope
     expected_type
-    ~in_:implicit_env
-    ~closure:[ expected_type ]
-    ~with_:(fun head gscheme ->
-      (* Instantiate the type scheme*)
-      let _instantiation, implicits = instantiate ~state ~env gscheme expected_type in
+    ~with_:(fun head ~implicit_spine gscheme ->
+      let curr_region = env.curr_region in
+      (* Instantiate the type scheme *)
+      let _instantiation = instantiate ~state ~env gscheme expected_type in
+      (* Reconstruct the implicit spine using unification *)
+      let implicits =
+        List.init implicit_spine ~f:(fun _ -> G.create_var ~state ~curr_region ())
+      in
+      let implicit_arrow =
+        List.fold_right
+          implicits
+          ~init:(G.create_var ~state ~curr_region ())
+          ~f:(fun implicit ret ->
+            G.create_former
+              ~state
+              ~curr_region
+              { shape = Sh_implicit_arrow; args = [ implicit; ret ] })
+      in
+      unify ~state ~env implicit_arrow expected_type;
+      (* At this point, implicits contains the types that we must recursively resolve *)
       let termination_budget =
         Termination.Budget.consume head expected_type termination_budget
       in
@@ -561,38 +710,26 @@ let rec resolve_implicit ~state ~env ~termination_budget ~implicit_env expected_
         in
         List.iter
           implicits
-          ~f:(resolve_implicit ~state ~env ~termination_budget ~implicit_env))
+          ~f:(resolve_implicit ~state ~env ~termination_budget ~implicit_scope))
 ;;
 
-let resolve_toplevel_implicits ~state ~env implicits =
-  let implicit_env = Env.implicit_env env in
-  List.iter
-    implicits
-    ~f:
-      (resolve_implicit
-         ~state
-         ~env
-         ~termination_budget:Termination.Budget.initial
-         ~implicit_env)
-;;
-
-let explicit_instantiate ~state ~env gscheme expected_type =
-  let _, implicits = instantiate ~state ~env gscheme expected_type in
-  match implicits with
-  | [] ->
-    (* Optimize for common case *)
-    ()
-  | _ :: _ -> resolve_toplevel_implicits ~state ~env implicits
-;;
-
-let over_instantiate ~state ~env ~overs expected_type =
-  Overload.match_
+let resolve_toplevel_implicit
+      ~state
+      ~env
+      ~(implicit_scope : Constraint.Implicit_scope.t)
+      expected_type
+  =
+  let implicit_scope =
+    implicit_scope.vars
+    |> Set.to_list
+    |> List.map ~f:(fun var -> var, Env.find_var env var)
+  in
+  resolve_implicit
     ~state
     ~env
+    ~termination_budget:Termination.Budget.initial
+    ~implicit_scope
     expected_type
-    ~in_:overs
-    ~closure:[ expected_type ]
-    ~with_:(fun _ gscheme -> explicit_instantiate ~state ~env gscheme expected_type)
 ;;
 
 let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
@@ -632,13 +769,10 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     let var_gscheme = Env.find_var env var in
     [%log.global.debug
       "Instantiating scheme" (var : Constraint.Var.t) (var_gscheme : G.Scheme.t)];
-    explicit_instantiate ~state ~env var_gscheme expected_gtype
-  | Over_instance (vars, expected_type) ->
-    [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
-    let expected_gtype = gtype_of_type ~state ~env expected_type in
-    [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
-    let overs = List.map vars ~f:(fun over_var -> over_var, Env.find_var env over_var) in
-    over_instantiate ~state ~env ~overs expected_gtype
+    let (_quantifiers : unit -> G.Type.t list) =
+      instantiate ~state ~env var_gscheme expected_gtype
+    in
+    ()
   | Exists (type_var, cst) ->
     [%log.global.debug "Binding unification for type_var" (type_var : Type.Var.t)];
     let env = exists ~state ~env ~type_var in
@@ -692,17 +826,14 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
         { matchee = gmatchee; closure = gclosure; case; else_; error }
     in
     ()
-  | Let_implicit (var_name, in_) ->
-    let env = Env.add_implicit_var env var_name in
-    self ~state ~env in_
-  | Implicit expected_type ->
+  | Implicit (expected_type, implicit_scope) ->
     [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
     let expected_gtype = gtype_of_type ~state ~env expected_type in
     [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
-    resolve_toplevel_implicits ~state ~env [ expected_gtype ]
+    resolve_toplevel_implicit ~state ~env ~implicit_scope expected_gtype
   | With_range (t, range) -> solve ~state ~env:(Env.with_range env ~range) t
 
-and solve_let_binding ~state ~env { type_vars; implicits; in_; bindings } =
+and solve_let_binding ~state ~env { type_vars; in_; bindings } =
   let env = Env.enter_new_region ~state env in
   [%log.global.debug "Entered new region" (env : Env.t)];
   let env =
@@ -717,9 +848,6 @@ and solve_let_binding ~state ~env { type_vars; implicits; in_; bindings } =
       (env : Env.t)];
   [%log.global.debug "Solving scheme's constraint"];
   solve ~state ~env in_;
-  let gimplicits =
-    List.map implicits ~f:(fun implicit -> gtype_of_type ~state ~env implicit)
-  in
   let gbindings =
     List.map bindings ~f:(fun { binding_var; binding_type } ->
       [%log.global.debug
@@ -727,7 +855,7 @@ and solve_let_binding ~state ~env { type_vars; implicits; in_; bindings } =
       let binding_gtype = gtype_of_type ~state ~env binding_type in
       [%log.global.debug
         "Type of binding" (binding_var : Constraint.Var.t) (binding_gtype : G.Type.t)];
-      let gscheme = Env.create_scheme env ~implicits:gimplicits binding_gtype in
+      let gscheme = Env.create_scheme env binding_gtype in
       binding_var, gscheme)
   in
   [%log.global.debug "Bindings" (gbindings : (Constraint.Var.t * G.Scheme.t) list)];
@@ -776,7 +904,7 @@ let solve
           "Region tree is not empty"
             (state.region_tree : G.Type.t G.Pool.t Tree.With_dirty.t)];
     if not (List.is_empty shape_var_errors)
-    then Error.raise ~range:None @@ Cannot_discharge_match_constraints shape_var_errors;
+    then Error.raise @@ Cannot_discharge_match_constraints shape_var_errors;
     (* If we have no remaining shape var errors, then it must be the case that we have 
        no alive regions. *)
     let num_type_partially_generalized_regions = State.num_alive_regions state in
@@ -805,10 +933,10 @@ let solve
        The first type will have the 'newest' allocated variables *)
     let dtype1 = decoder gtype1 in
     let dtype2 = decoder gtype2 in
-    Error (Error.create ~range (Cannot_unify (dtype1, dtype2)))
+    Error (Error.create ?range (Cannot_unify (dtype1, dtype2)))
   | G.Suspended_match.Cannot_match_on_rigid report
   | G.Suspended_match.Inconsistent_defaults report ->
     (* Catch suspended match constraint exceptions *)
-    Error (Error.create ~range (Unsatisfiable report))
+    Error (Error.create ?range (Unsatisfiable report))
   | Error.T err -> Error err
 ;;

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -602,7 +602,7 @@ module Implicit_resolution = struct
           else
             with_
               candidate_var
-              ~implicit_spine:(expected_spine - candidate_spine)
+              ~implicit_spine:(candidate_spine - expected_spine)
               candidate_scheme
         in
         strip_implicits_for_candidates
@@ -663,23 +663,19 @@ let rec resolve_implicit
     expected_type
     ~with_:(fun head ~implicit_spine gscheme ->
       let curr_region = env.curr_region in
-      (* Instantiate the type scheme *)
-      let _instantiation = instantiate ~state ~env gscheme expected_type in
-      (* Reconstruct the implicit spine using unification *)
+      (* Reconstruct the implicit spine *)
       let implicits =
         List.init implicit_spine ~f:(fun _ -> G.create_var ~state ~curr_region ())
       in
-      let implicit_arrow =
-        List.fold_right
-          implicits
-          ~init:(G.create_var ~state ~curr_region ())
-          ~f:(fun implicit ret ->
-            G.create_former
-              ~state
-              ~curr_region
-              { shape = Sh_implicit_arrow; args = [ implicit; ret ] })
+      let implicit_type =
+        List.fold_right implicits ~init:expected_type ~f:(fun implicit ret ->
+          G.create_former
+            ~state
+            ~curr_region
+            { shape = Sh_implicit_arrow; args = [ implicit; ret ] })
       in
-      unify ~state ~env implicit_arrow expected_type;
+      (* Instantiate the type scheme *)
+      let _instantiation = instantiate ~state ~env gscheme implicit_type in
       (* At this point, implicits contains the types that we must recursively resolve *)
       let termination_budget =
         Termination.Budget.consume head expected_type termination_budget

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -227,10 +227,12 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     [%log.global.debug
       "Closure of suspended match" (gclosure : G.Suspended_match.closure)];
     (* Register match for the shape *)
-    let case ~curr_region ~shape ~args =
+    let case ~shape ~args =
       [%log.global.debug "Entered match handler" (shape : Principal_shape.t)];
       (* Enter region and construct env *)
-      let env = Env.of_gclosure gclosure ~closure ~curr_region ~range:env.range in
+      let env =
+        Env.of_gclosure gclosure ~closure ~curr_region:env.curr_region ~range:env.range
+      in
       [%log.global.debug "Handler env" (env : Env.t)];
       [%log.global.debug "Handler state" (state : State.t)];
       (* Solve *)
@@ -248,10 +250,13 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
       else_ ()
     in
     [%log.global.debug "Suspending match..."];
-    G.Suspended_match.match_or_yield
-      ~state
-      ~curr_region:env.curr_region
-      { matchee = gmatchee; closure = gclosure; case; else_; error }
+    let _ =
+      G.Suspended_match.match_or_yield
+        ~state
+        ~curr_region:env.curr_region
+        { matchee = gmatchee; closure = gclosure; case; else_; error }
+    in
+    ()
   | With_range (t, range) -> solve ~state ~env:(Env.with_range env ~range) t
 
 and solve_let_binding ~state ~env { type_vars; in_; bindings } =

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -200,7 +200,10 @@ module Overload = struct
     val try_resolve : t -> f:(G.Scheme.t -> 'a) -> 'a
     val iter : t -> f:(key:Constraint.Var.t -> data:G.Scheme.t -> unit) -> unit
   end = struct
-    type t = { mutable remaining_overs : over Constraint.Var.Map.t }
+    type t =
+      { mutable remaining_overs : over Constraint.Var.Map.t
+      ; mutable has_raised_error : bool
+      }
 
     and over =
       { mutable over_handlers :
@@ -219,12 +222,21 @@ module Overload = struct
         ~f:Principal_shape.Var.Registered_handler.cancel_if_pending
     ;;
 
+    let error t ~range =
+      if t.has_raised_error
+      then None
+      else (
+        t.has_raised_error <- true;
+        Some Omniml_error.(ambiguous_overloading ~range))
+    ;;
+
     let create initial_overs =
       { remaining_overs =
           initial_overs
           |> List.map ~f:(fun (over_var, over_scheme) ->
             over_var, { over_scheme; over_handlers = [] })
           |> Constraint.Var.Map.of_alist_exn
+      ; has_raised_error = false
       }
     ;;
 
@@ -276,7 +288,11 @@ module Overload = struct
           ; closure = { variables = closure; schemes = [ over.over_scheme ] }
           ; case = with_
           ; else_ = (fun () -> Omniml_error.(raise @@ ambiguous_overloading ~range))
-          ; error = (fun _ -> Omniml_error.ambiguous_overloading ~range)
+          ; error =
+              (function
+                | Cannot_default -> error in_ ~range
+                | Inconsistent_default _ -> assert false
+                | Matchee_is_rigid -> Some Omniml_error.(ambiguous_overloading ~range))
           }
         |> Option.iter ~f:(add_handler_over over)
     ;;
@@ -473,6 +489,7 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
       [%log.global.debug "Entered match default handler"];
       else_ ()
     in
+    let error e = Some (error e) in
     [%log.global.debug "Suspending match..."];
     let _ : Principal_shape.Var.Registered_handler.t option =
       G.Suspended_match.match_or_yield

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -25,103 +25,113 @@ module Error = struct
 end
 
 module Termination = struct
-  module History = struct
-    type t = { seen : int Constraint.Var.Map.t } [@@deriving sexp_of]
+  module Budget = struct
+    module Spec = struct
+      module type S = sig
+        type t [@@deriving sexp_of, compare]
 
-    let empty = { seen = Constraint.Var.Map.empty }
-
-    let mark t var =
-      { seen = Map.update t.seen var ~f:(Option.value_map ~default:1 ~f:Int.succ) }
-    ;;
-
-    let reset t var = { seen = Map.set t.seen ~key:var ~data:0 }
-
-    let count t var =
-      try Map.find_exn t.seen var with
-      | _ -> 0
-    ;;
-  end
-
-  module Witness = struct
-    module Elab = struct
-      module T = struct
-        type 'a t = Decoded_type.Decoder.t -> 'a
-
-        let return x _dec = x
-        let bind t ~f = fun dec -> f (t dec) dec
-        let map = `Define_using_bind
+        val initial : t
+        val consume : Constraint.Var.t -> Decoded_type.t Lazy.t -> t -> t option
       end
 
-      include T
-      include Monad.Make (T)
+      type t = ((module S)[@sexp.opaque]) [@@deriving sexp_of]
 
-      let decode_type type_ : Decoded_type.t t = fun dec -> dec type_
-      let run t = t (Decoded_type.Decoder.create ())
+      let unlimited : t =
+        (module struct
+          type t = unit [@@deriving sexp_of, compare]
+
+          let initial = ()
+          let consume _var _type _t = Some ()
+        end)
+      ;;
+
+      let bounded_by n : t =
+        (module struct
+          type t = int [@@deriving sexp_of, compare]
+
+          let initial = n
+          let consume _var _type t = if t = 0 then None else Some (t - 1)
+        end)
+      ;;
     end
 
-    module T = struct
-      type t = desc ref
-
-      and desc =
-        | Hole
-        | Spine of spine
-
-      and spine =
-        { head : Constraint.Var.t
-        ; instantiation : unit -> G.Type.t list
-        ; args : t list
-        }
-      [@@deriving sexp_of]
-    end
-
-    include T
-
-    module Spine = struct
-      type t = T.spine [@@deriving sexp_of]
-
-      let create ~head ~instantiation ~args = { head; instantiation; args }
-      let head t = t.head
-      let instantiation t = t.instantiation () |> List.map ~f:Elab.decode_type |> Elab.all
-      let args t = t.args
-    end
-
-    type view = desc =
-      | Hole
-      | Spine of spine
+    type t =
+      | Initial
+      | Consume of Constraint.Var.t * G.Type.t * t
     [@@deriving sexp_of]
 
-    let view (t : t) = !t
-    let hole () = ref Hole
-    let spine spine = ref (Spine spine)
+    let initial = Initial
+    let consume var type_ t = Consume (var, type_, t)
   end
 
   module Check = struct
+    module Pressure = struct
+      (* To decide when the solver should check the termination budget, 
+         we track a heuristic "peassure": the number of times a variable 
+         has been seen recursively. 
+
+         If this count exceeds a threshold, the budget is evaluated 
+         eargerly; otherwise evaluation is delayed until after constraint 
+         solving. *)
+
+      type t = { recursive_occurrences : int Constraint.Var.Map.t } [@@deriving sexp_of]
+
+      let empty = { recursive_occurrences = Constraint.Var.Map.empty }
+
+      let increase t var =
+        { recursive_occurrences =
+            Map.update
+              t.recursive_occurrences
+              var
+              ~f:(Option.value_map ~default:1 ~f:Int.succ)
+        }
+      ;;
+
+      let reset t var =
+        { recursive_occurrences = Map.set t.recursive_occurrences ~key:var ~data:0 }
+      ;;
+
+      let get t var =
+        try Map.find_exn t.recursive_occurrences var with
+        | _ -> 0
+      ;;
+
+      let threshold = 256
+    end
+
     type t =
-      { recursive_occurrence_threshold : int
-      ; rejects : Witness.t -> bool Witness.Elab.t
+      { budget_spec : Budget.Spec.t
+      ; mutable delayed_checks : (Range.t option * Budget.t) list
       }
     [@@deriving sexp_of]
 
-    let trigger_check t history ~on =
-      History.count history on > t.recursive_occurrence_threshold
+    let create budget_spec = { budget_spec; delayed_checks = [] }
+
+    let raise_if_exceeds t ?range budget =
+      let (module Tbs) = t.budget_spec in
+      let decode_type type_ =
+        lazy
+          (let dec = Decoded_type.Decoder.create () in
+           dec type_)
+      in
+      let rec interpret = function
+        | Budget.Initial -> Tbs.initial
+        | Consume (var, type_, budget_term) ->
+          let budget = interpret budget_term in
+          (match Tbs.consume var (decode_type type_) budget with
+           | Some budget -> budget
+           | None -> Error.(raise ~range @@ Resolution_termination_check_failed))
+      in
+      ignore (interpret budget : Tbs.t)
     ;;
 
-    let check_if_exceeded_threshold t history ~on ~root_witness =
-      if trigger_check t history ~on
-      then `Check (t.rejects root_witness |> Witness.Elab.run)
-      else `No_check
+    let add_delayed_check t ?range termination_budget =
+      t.delayed_checks <- (range, termination_budget) :: t.delayed_checks
     ;;
 
-    let disabled =
-      { recursive_occurrence_threshold = Int.max_value
-      ; rejects = (fun _ -> Witness.Elab.return false)
-      }
-    ;;
-
-    let threshold n =
-      { recursive_occurrence_threshold = n
-      ; rejects = (fun _ -> Witness.Elab.return true)
-      }
+    let force_delayed_checks t =
+      List.iter t.delayed_checks ~f:(fun (range, budget) ->
+        raise_if_exceeds t ?range budget)
     ;;
   end
 end
@@ -133,8 +143,8 @@ module Env = struct
     ; implicit_vars : Constraint.Var.Set.t
     ; curr_region : G.Region.t
     ; range : Range.t option
-    ; termination_history : Termination.History.t
     ; termination_check : Termination.Check.t
+    ; termination_pressure : Termination.Check.Pressure.t
     }
   [@@deriving sexp_of]
 
@@ -147,8 +157,8 @@ module Env = struct
     ; implicit_vars = Constraint.Var.Set.empty
     ; curr_region
     ; range
-    ; termination_history = Termination.History.empty
     ; termination_check
+    ; termination_pressure = Termination.Check.Pressure.empty
     }
   ;;
 
@@ -162,12 +172,17 @@ module Env = struct
 
   let add_implicit_var t var = { t with implicit_vars = Set.add t.implicit_vars var }
 
-  let mark_var_in_termination_history t var =
-    { t with termination_history = Termination.History.mark t.termination_history var }
+  let increase_termination_pressure t var =
+    { t with
+      termination_pressure =
+        Termination.Check.Pressure.increase t.termination_pressure var
+    }
   ;;
 
-  let reset_var_in_termination_history t var =
-    { t with termination_history = Termination.History.reset t.termination_history var }
+  let reset_termination_pressure t var =
+    { t with
+      termination_pressure = Termination.Check.Pressure.reset t.termination_pressure var
+    }
   ;;
 
   let find_type_var t type_var =
@@ -507,14 +522,7 @@ let instantiate ~(state : State.t) ~(env : Env.t) gscheme expected_type =
   instantiation, implicits
 ;;
 
-let rec resolve_implicit
-          ~state
-          ~env
-          ~root_witness
-          ~curr_witness
-          ~implicit_env
-          expected_type
-  =
+let rec resolve_implicit ~state ~env ~termination_budget ~implicit_env expected_type =
   Overload.match_
     ~state
     ~env
@@ -523,54 +531,49 @@ let rec resolve_implicit
     ~closure:[ expected_type ]
     ~with_:(fun head gscheme ->
       (* Instantiate the type scheme*)
-      let instantiation, implicits = instantiate ~state ~env gscheme expected_type in
-      (* Allocate witnesses for each implicit and set the current witness *)
-      let implicit_witnesses =
-        List.map implicits ~f:(fun _implicit -> Termination.Witness.hole ())
+      let _instantiation, implicits = instantiate ~state ~env gscheme expected_type in
+      let termination_budget =
+        Termination.Budget.consume head expected_type termination_budget
       in
-      (curr_witness
-       := Termination.Witness.(
-            Spine (Spine.create ~head ~instantiation ~args:implicit_witnesses)));
-      (* Mark the variable in the history *)
-      let env = Env.mark_var_in_termination_history env head in
-      let env =
-        match
-          Termination.Check.check_if_exceeded_threshold
-            env.termination_check
-            env.termination_history
-            ~on:head
-            ~root_witness
-        with
-        | `No_check -> env
-        | `Check rejects ->
-          if rejects
-          then Env.raise env Resolution_termination_check_failed
-          else
+      match implicits with
+      | [] ->
+        (* A leaf constraint in resolution. Despite the fact that resolution has 
+           terminated, we need to check the termination budget computation after 
+           constraint solving finishes. *)
+        Termination.Check.add_delayed_check
+          env.termination_check
+          ?range:env.range
+          termination_budget
+      | _ :: _ ->
+        (* Increase termination pressure for [head] *)
+        let env = Env.increase_termination_pressure env head in
+        (* Check if pressure threshold has exceeded *)
+        let env =
+          if Termination.Check.Pressure.(get env.termination_pressure head > threshold)
+          then (
+            Termination.Check.raise_if_exceeds
+              env.termination_check
+              ?range:env.range
+              termination_budget;
             (* TODO: Reset globally instead of just in current path *)
-            Env.reset_var_in_termination_history env head
-      in
-      (* Safety: List.length implicit_witnesses = List.length implicits by construction *)
-      List.iter2_exn implicits implicit_witnesses ~f:(fun implicit implicit_witness ->
-        resolve_implicit
-          ~state
-          ~env
-          ~root_witness
-          ~curr_witness:implicit_witness
-          ~implicit_env
-          implicit))
+            Env.reset_termination_pressure env head)
+          else env
+        in
+        List.iter
+          implicits
+          ~f:(resolve_implicit ~state ~env ~termination_budget ~implicit_env))
 ;;
 
 let resolve_toplevel_implicits ~state ~env implicits =
   let implicit_env = Env.implicit_env env in
-  List.iter implicits ~f:(fun implicit ->
-    let root_witness = Termination.Witness.hole () in
-    resolve_implicit
-      ~state
-      ~env
-      ~root_witness
-      ~curr_witness:root_witness
-      ~implicit_env
-      implicit)
+  List.iter
+    implicits
+    ~f:
+      (resolve_implicit
+         ~state
+         ~env
+         ~termination_budget:Termination.Budget.initial
+         ~implicit_env)
 ;;
 
 let explicit_instantiate ~state ~env gscheme expected_type =
@@ -739,15 +742,19 @@ and gclosure_of_closure ~env closure : G.Suspended_match.closure =
 let solve
   :  ?range:Range.t
   -> ?defaulting:Omniml_options.Defaulting.t
-  -> ?termination_check:Termination.Check.t
+  -> ?termination_budget_spec:Termination.Budget.Spec.t
   -> Constraint.t
   -> (unit, Error.t) result
   =
-  fun ?range ?defaulting ?(termination_check = Termination.Check.disabled) cst ->
+  fun ?range
+    ?defaulting
+    ?(termination_budget_spec = Termination.Budget.Spec.unlimited)
+    cst ->
   try
     Scheduler.(clear (t ()));
     let state = State.create ?defaulting () in
     let root_region = State.root_region state in
+    let termination_check = Termination.Check.create termination_budget_spec in
     let env = Env.empty ~curr_region:root_region ~range ~termination_check in
     [%log.global.debug "Initial env and state" (state : State.t) (env : Env.t)];
     solve ~state ~env cst;
@@ -787,6 +794,8 @@ let solve
             (num_shape_partially_generalized_regions : int)
             (num_type_partially_generalized_regions : int)
             (state : State.t)];
+    (* Check that all termination budgets *)
+    Termination.Check.force_delayed_checks termination_check;
     Ok ()
   with
   (* Catch solver exceptions *)

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -15,12 +15,104 @@ module Error = struct
     | Rigid_variable_escape
     | Cannot_unify of Decoded_type.t * Decoded_type.t
     | Cannot_discharge_match_constraints of Omniml_error.t list
+    | Resolution_termination_check_failed
   [@@deriving sexp]
 
   exception T of t
 
   let create ~range it = { it; range }
   let raise ~range it = raise @@ T { it; range }
+end
+
+module Termination = struct
+  module History = struct
+    type t = { seen : int Constraint.Var.Map.t } [@@deriving sexp_of]
+
+    let empty = { seen = Constraint.Var.Map.empty }
+
+    let mark t var =
+      { seen = Map.update t.seen var ~f:(Option.value_map ~default:1 ~f:Int.succ) }
+    ;;
+
+    let count t var =
+      try Map.find_exn t.seen var with
+      | _ -> 0
+    ;;
+  end
+
+  module Witness = struct
+    module Elab = struct
+      module T = struct
+        type 'a t = Decoded_type.Decoder.t -> 'a
+
+        let return x _dec = x
+        let bind t ~f = fun dec -> f (t dec) dec
+        let map = `Define_using_bind
+      end
+
+      include T
+      include Monad.Make (T)
+
+      let decode_type type_ : Decoded_type.t t = fun dec -> dec type_
+      let run t = t (Decoded_type.Decoder.create ())
+    end
+
+    module T = struct
+      type t = desc ref
+
+      and desc =
+        | Hole
+        | Spine of spine
+
+      and spine =
+        { head : Constraint.Var.t
+        ; instantiation : unit -> G.Type.t list
+        ; args : t list
+        }
+      [@@deriving sexp_of]
+    end
+
+    include T
+
+    module Spine = struct
+      type t = T.spine [@@deriving sexp_of]
+
+      let create ~head ~instantiation ~args = { head; instantiation; args }
+      let head t = t.head
+      let instantiation t = t.instantiation () |> List.map ~f:Elab.decode_type |> Elab.all
+      let args t = t.args
+    end
+
+    type view = desc
+
+    let view (t : t) = !t
+    let hole () = ref Hole
+    let spine spine = ref (Spine spine)
+  end
+
+  module Check = struct
+    type t =
+      { recursive_occurrence_threshold : int
+      ; rejects : Witness.t -> bool Witness.Elab.t
+      }
+    [@@deriving sexp_of]
+
+    let trigger_check t history ~on =
+      History.count history on > t.recursive_occurrence_threshold
+    ;;
+
+    let check_if_exceeded_threshold t history ~on ~root_witness =
+      if trigger_check t history ~on
+      then `Check (t.rejects root_witness |> Witness.Elab.run)
+      else `No_check
+    ;;
+
+    let default =
+      { recursive_occurrence_threshold = 256
+      ; rejects = (fun _ -> Witness.Elab.return true)
+      }
+    ;;
+  end
 end
 
 module Env = struct
@@ -30,18 +122,22 @@ module Env = struct
     ; implicit_vars : Constraint.Var.Set.t
     ; curr_region : G.Region.t
     ; range : Range.t option
+    ; termination_history : Termination.History.t
+    ; termination_check : Termination.Check.t
     }
   [@@deriving sexp_of]
 
   let raise t err = Error.raise ~range:t.range err
   let with_range t ~range = { t with range = Some range }
 
-  let empty ~range ~curr_region =
+  let empty ~range ~curr_region ~termination_check =
     { type_vars = Type.Var.Map.empty
     ; expr_vars = Constraint.Var.Map.empty
     ; implicit_vars = Constraint.Var.Set.empty
     ; curr_region
     ; range
+    ; termination_history = Termination.History.empty
+    ; termination_check
     }
   ;;
 
@@ -54,6 +150,10 @@ module Env = struct
   ;;
 
   let add_implicit_var t var = { t with implicit_vars = Set.add t.implicit_vars var }
+
+  let mark_var_in_termination_history t var =
+    { t with termination_history = Termination.History.mark t.termination_history var }
+  ;;
 
   let find_type_var t type_var =
     try Map.find_exn t.type_vars type_var with
@@ -82,6 +182,7 @@ module Env = struct
         ~closure:({ type_vars; vars } : Constraint.Closure.t)
         ~range
         ~curr_region
+        ~termination_check
     =
     let type_vars =
       List.zip_exn type_vars gclosure.variables |> Type.Var.Map.of_alist_exn
@@ -89,13 +190,17 @@ module Env = struct
     let expr_vars =
       List.zip_exn vars gclosure.schemes |> Constraint.Var.Map.of_alist_exn
     in
-    { (empty ~range ~curr_region) with type_vars; expr_vars }
+    { (empty ~range ~curr_region ~termination_check) with type_vars; expr_vars }
   ;;
 
   let prev_region t =
     match t.curr_region.parent with
     | None -> t.curr_region
     | Some parent -> parent
+  ;;
+
+  let implicit_env t =
+    t.implicit_vars |> Set.to_list |> List.map ~f:(fun var -> var, find_var t var)
   ;;
 end
 
@@ -197,7 +302,7 @@ module Overload = struct
 
     exception Not_resolved
 
-    val try_resolve : t -> f:(G.Scheme.t -> 'a) -> 'a
+    val try_resolve : t -> f:(Constraint.Var.t -> G.Scheme.t -> 'a) -> 'a
     val iter : t -> f:(key:Constraint.Var.t -> data:G.Scheme.t -> unit) -> unit
   end = struct
     type t =
@@ -254,9 +359,9 @@ module Overload = struct
       then raise Not_resolved
       else (
         match Map.to_alist t.remaining_overs with
-        | [ (_over_var, over) ] ->
+        | [ (over_var, over) ] ->
           cancel_over over;
-          f over.over_scheme
+          f over_var over.over_scheme
         | _ -> assert false)
     ;;
 
@@ -379,31 +484,91 @@ module Overload = struct
   ;;
 end
 
-let rec implicit_instantiate ~(state : State.t) ~(env : Env.t) gscheme expected_type =
-  let implicits, actual_type =
+let instantiate ~(state : State.t) ~(env : Env.t) gscheme expected_type =
+  let instantiation, implicits, actual_type =
     G.instantiate ~state ~curr_region:env.curr_region gscheme
   in
   unify ~state ~env actual_type expected_type;
-  match implicits with
-  | [] ->
-    (* Optimize for the common case *)
-    ()
-  | _ ->
-    let env_implicits =
-      env.implicit_vars
-      |> Set.to_list
-      |> List.map ~f:(fun var -> var, Env.find_var env var)
-    in
-    List.iter implicits ~f:(over_instantiate ~state ~env ~in_:env_implicits)
+  instantiation, implicits
+;;
 
-and over_instantiate ~state ~env expected_type ~in_ =
+let rec resolve_implicit
+          ~state
+          ~env
+          ~root_witness
+          ~curr_witness
+          ~implicit_env
+          expected_type
+  =
   Overload.match_
     ~state
     ~env
     expected_type
-    ~in_
+    ~in_:implicit_env
     ~closure:[ expected_type ]
-    ~with_:(fun gscheme -> implicit_instantiate ~state ~env gscheme expected_type)
+    ~with_:(fun head gscheme ->
+      (* Instantiate the type scheme*)
+      let instantiation, implicits = instantiate ~state ~env gscheme expected_type in
+      (* Allocate witnesses for each implicit and set the current witness *)
+      let implicit_witnesses =
+        List.map implicits ~f:(fun _implicit -> Termination.Witness.hole ())
+      in
+      (curr_witness
+       := Termination.Witness.(
+            Spine (Spine.create ~head ~instantiation ~args:implicit_witnesses)));
+      (* Mark the variable in the history *)
+      let env = Env.mark_var_in_termination_history env head in
+      (match
+         Termination.Check.check_if_exceeded_threshold
+           env.termination_check
+           env.termination_history
+           ~on:head
+           ~root_witness
+       with
+       | `No_check -> ()
+       | `Check rejects ->
+         if rejects then Env.raise env Resolution_termination_check_failed);
+      (* Safety: List.length implicit_witnesses = List.length implicits by construction *)
+      List.iter2_exn implicits implicit_witnesses ~f:(fun implicit implicit_witness ->
+        resolve_implicit
+          ~state
+          ~env
+          ~root_witness
+          ~curr_witness:implicit_witness
+          ~implicit_env
+          implicit))
+;;
+
+let resolve_toplevel_implicits ~state ~env implicits =
+  let implicit_env = Env.implicit_env env in
+  List.iter implicits ~f:(fun implicit ->
+    let root_witness = Termination.Witness.hole () in
+    resolve_implicit
+      ~state
+      ~env
+      ~root_witness
+      ~curr_witness:root_witness
+      ~implicit_env
+      implicit)
+;;
+
+let explicit_instantiate ~state ~env gscheme expected_type =
+  let _, implicits = instantiate ~state ~env gscheme expected_type in
+  match implicits with
+  | [] ->
+    (* Optimize for common case *)
+    ()
+  | _ :: _ -> resolve_toplevel_implicits ~state ~env implicits
+;;
+
+let over_instantiate ~state ~env ~overs expected_type =
+  Overload.match_
+    ~state
+    ~env
+    expected_type
+    ~in_:overs
+    ~closure:[ expected_type ]
+    ~with_:(fun _ gscheme -> explicit_instantiate ~state ~env gscheme expected_type)
 ;;
 
 let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
@@ -443,13 +608,13 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     let var_gscheme = Env.find_var env var in
     [%log.global.debug
       "Instantiating scheme" (var : Constraint.Var.t) (var_gscheme : G.Scheme.t)];
-    implicit_instantiate ~state ~env var_gscheme expected_gtype
+    explicit_instantiate ~state ~env var_gscheme expected_gtype
   | Over_instance (vars, expected_type) ->
     [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
     let expected_gtype = gtype_of_type ~state ~env expected_type in
     [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
     let overs = List.map vars ~f:(fun over_var -> over_var, Env.find_var env over_var) in
-    over_instantiate ~state ~env expected_gtype ~in_:overs
+    over_instantiate ~state ~env ~overs expected_gtype
   | Exists (type_var, cst) ->
     [%log.global.debug "Binding unification for type_var" (type_var : Type.Var.t)];
     let env = exists ~state ~env ~type_var in
@@ -471,7 +636,12 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
       [%log.global.debug "Entered match handler" (shape : Principal_shape.t)];
       (* Enter region and construct env *)
       let env =
-        Env.of_gclosure gclosure ~closure ~curr_region:env.curr_region ~range:env.range
+        Env.of_gclosure
+          gclosure
+          ~closure
+          ~curr_region:env.curr_region
+          ~range:env.range
+          ~termination_check:env.termination_check
       in
       [%log.global.debug "Handler env" (env : Env.t)];
       [%log.global.debug "Handler state" (state : State.t)];
@@ -505,12 +675,7 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
     let expected_gtype = gtype_of_type ~state ~env expected_type in
     [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
-    let env_implicits =
-      env.implicit_vars
-      |> Set.to_list
-      |> List.map ~f:(fun var -> var, Env.find_var env var)
-    in
-    over_instantiate ~state ~env expected_gtype ~in_:env_implicits
+    resolve_toplevel_implicits ~state ~env [ expected_gtype ]
   | With_range (t, range) -> solve ~state ~env:(Env.with_range env ~range) t
 
 and solve_let_binding ~state ~env { type_vars; implicits; in_; bindings } =
@@ -553,15 +718,19 @@ and gclosure_of_closure ~env closure : G.Suspended_match.closure =
 let solve
   :  ?range:Range.t
   -> ?defaulting:Omniml_options.Defaulting.t
+  -> ?termination_check:Termination.Check.t
   -> Constraint.t
   -> (unit, Error.t) result
   =
-  fun ?range ?defaulting cst ->
+  fun ?range ?defaulting ?termination_check cst ->
+  let termination_check =
+    Option.value termination_check ~default:Termination.Check.default
+  in
   try
     Scheduler.(clear (t ()));
     let state = State.create ?defaulting () in
     let root_region = State.root_region state in
-    let env = Env.empty ~curr_region:root_region ~range in
+    let env = Env.empty ~curr_region:root_region ~range ~termination_check in
     [%log.global.debug "Initial env and state" (state : State.t) (env : Env.t)];
     solve ~state ~env cst;
     [%log.global.debug "State" (state : State.t)];

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -177,7 +177,29 @@ let match_type
 ;;
 
 module Overload = struct
-  module Switch = struct
+  module Switch : sig
+    type t [@@deriving sexp_of]
+
+    val create : (Constraint.Var.t * G.Scheme.t) list -> t
+
+    val match_
+      :  state:State.t
+      -> env:Env.t
+      -> in_:t
+      -> curr_region:[ `Env | `Over ]
+      -> over:Constraint.Var.t
+      -> G.Type.t
+      -> closure:G.Type.t list
+      -> with_:(shape:Principal_shape.t -> args:G.Type.t list -> unit)
+      -> unit
+
+    val remove : t -> Constraint.Var.t -> unit
+
+    exception Not_resolved
+
+    val try_resolve : t -> f:(G.Scheme.t -> 'a) -> 'a
+    val iter : t -> f:(key:Constraint.Var.t -> data:G.Scheme.t -> unit) -> unit
+  end = struct
     type t = { mutable remaining_overs : over Constraint.Var.Map.t }
 
     and over =
@@ -186,6 +208,16 @@ module Overload = struct
       ; over_scheme : G.Scheme.t
       }
     [@@deriving sexp_of]
+
+    let add_handler_over over handler =
+      over.over_handlers <- handler :: over.over_handlers
+    ;;
+
+    let cancel_over over =
+      List.iter
+        over.over_handlers
+        ~f:Principal_shape.Var.Registered_handler.cancel_if_pending
+    ;;
 
     let create initial_overs =
       { remaining_overs =
@@ -196,49 +228,47 @@ module Overload = struct
       }
     ;;
 
-    let remove_over t over =
-      Map.find t.remaining_overs over
-      |> Option.iter ~f:(fun { over_handlers; over_scheme = _ } ->
-        List.iter
-          over_handlers
-          ~f:Principal_shape.Var.Registered_handler.cancel_if_pending;
-        t.remaining_overs <- Map.remove t.remaining_overs over)
+    let remove t over_var =
+      Map.find t.remaining_overs over_var
+      |> Option.iter ~f:(fun over ->
+        cancel_over over;
+        t.remaining_overs <- Map.remove t.remaining_overs over_var)
     ;;
-  end
 
-  let is_ambiguous ~(switch : Switch.t) = Map.length switch.remaining_overs > 1
+    exception Not_resolved
 
-  let if_unique ~(switch : Switch.t) ~do_ =
-    if is_ambiguous ~switch
-    then ()
-    else (
-      match Map.to_alist switch.remaining_overs with
-      | [ (_over_var, over) ] -> do_ over.over_scheme
-      | _ -> assert false)
-  ;;
+    let try_resolve t ~f =
+      if Map.length t.remaining_overs <> 1
+      then raise Not_resolved
+      else (
+        match Map.to_alist t.remaining_overs with
+        | [ (_over_var, over) ] ->
+          cancel_over over;
+          f over.over_scheme
+        | _ -> assert false)
+    ;;
 
-  let match_
-        ~(state : State.t)
-        ~(env : Env.t)
-        ~(switch : Switch.t)
-        ~curr_region
-        ~over
-        matchee
-        ~closure
-        ~with_
-    =
-    let range = Option.value_exn ~here:[%here] env.range in
-    match Map.find switch.remaining_overs over with
-    | None ->
-      (* overload was already removed, no need to generate any subsequent constraints *)
-      ()
-    | Some over ->
-      let curr_region =
-        match curr_region with
-        | `Env -> env.curr_region
-        | `Over -> over.over_scheme.region
-      in
-      let handler =
+    let match_
+          ~(state : State.t)
+          ~(env : Env.t)
+          ~(in_ : t)
+          ~curr_region
+          ~over
+          matchee
+          ~closure
+          ~with_
+      =
+      let range = Option.value_exn ~here:[%here] env.range in
+      match Map.find in_.remaining_overs over with
+      | None ->
+        (* overload was already removed, no need to generate any subsequent constraints *)
+        ()
+      | Some over ->
+        let curr_region =
+          match curr_region with
+          | `Env -> env.curr_region
+          | `Over -> over.over_scheme.region
+        in
         G.Suspended_match.match_or_yield
           ~state
           ~curr_region
@@ -248,11 +278,14 @@ module Overload = struct
           ; else_ = (fun () -> Omniml_error.(raise @@ ambiguous_overloading ~range))
           ; error = (fun _ -> Omniml_error.ambiguous_overloading ~range)
           }
-      in
-      (match handler with
-       | Some handler -> over.over_handlers <- handler :: over.over_handlers
-       | None -> ())
-  ;;
+        |> Option.iter ~f:(add_handler_over over)
+    ;;
+
+    let iter t ~f =
+      Map.iteri t.remaining_overs ~f:(fun ~key ~data:over ->
+        f ~key ~data:over.over_scheme)
+    ;;
+  end
 
   let rec filter_over
             ~(state : State.t)
@@ -264,10 +297,10 @@ module Overload = struct
             over_type_p
             expected_type_p
     =
-    match_
+    Switch.match_
       ~state
       ~env
-      ~switch
+      ~in_:switch
       ~curr_region:`Env
       ~over
       expected_type_p
@@ -283,10 +316,10 @@ module Overload = struct
           | _ -> false
         then ()
         else
-          match_
+          Switch.match_
             ~state
             ~env
-            ~switch
+            ~in_:switch
             ~curr_region:`Over
             ~over
             over_type_p
@@ -308,15 +341,16 @@ module Overload = struct
                       over_type_p_arg
                       expected_type_p_arg)
               else (
-                Switch.remove_over switch over;
-                if_unique ~switch ~do_:with_)))
+                Switch.remove switch over;
+                try Switch.try_resolve switch ~f:with_ with
+                | Switch.Not_resolved -> ())))
   ;;
 
   let match_ ~state ~env expected_type ~in_:overloads ~closure ~with_ =
     let switch = Switch.create overloads in
-    Map.iteri
-      switch.remaining_overs
-      ~f:(fun ~key:over ~data:{ over_scheme; over_handlers = _ } ->
+    try Switch.try_resolve switch ~f:with_ with
+    | Switch.Not_resolved ->
+      Switch.iter switch ~f:(fun ~key:over ~data:over_scheme ->
         filter_over
           ~state
           ~env

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -170,6 +170,116 @@ let match_type
   | Sh_poly poly_shape -> env, Poly poly_shape.scheme
 ;;
 
+module Over_switch = struct
+  type t = { mutable remaining_overs : over Constraint.Var.Map.t }
+
+  and over =
+    { mutable over_handlers : Principal_shape.Var.Registered_handler.t list
+    ; over_root : G.Type.t
+    }
+
+  let create initial_overs =
+    { remaining_overs =
+        initial_overs
+        |> List.map ~f:(fun (over_var, over_root) ->
+          over_var, { over_root; over_handlers = [] })
+        |> Constraint.Var.Map.of_alist_exn
+    }
+  ;;
+
+  let remove_over t over =
+    Map.find t.remaining_overs over
+    |> Option.iter ~f:(fun { over_handlers; over_root = _ } ->
+      List.iter over_handlers ~f:Principal_shape.Var.Registered_handler.cancel_if_pending;
+      t.remaining_overs <- Map.remove t.remaining_overs over)
+  ;;
+
+  let ambiguous t = Map.length t.remaining_overs > 1
+
+  let unify_if_unique ~state ~env t expected_type =
+    if ambiguous t
+    then ()
+    else (
+      match Map.to_alist t.remaining_overs with
+      | [ (_over_var, over) ] -> unify ~state ~env over.over_root expected_type
+      | _ -> assert false)
+  ;;
+
+  let over_match ~(state : State.t) ~(env : Env.t) t ~over matchee ~closure ~with_ =
+    let range = Option.value_exn ~here:[%here] env.range in
+    match Map.find t.remaining_overs over with
+    | None ->
+      (* overload was already removed, no need to generate any subsequent constraints *)
+      ()
+    | Some over ->
+      let handler =
+        G.Suspended_match.match_or_yield
+          ~state
+          ~curr_region:env.curr_region
+          { matchee
+          ; closure = { variables = over.over_root :: closure; schemes = [] }
+          ; case = with_
+          ; else_ = (fun () -> Omniml_error.(raise @@ ambiguous_overloading ~range))
+          ; error = (fun _ -> Omniml_error.ambiguous_overloading ~range)
+          }
+      in
+      (match handler with
+       | Some handler -> over.over_handlers <- handler :: over.over_handlers
+       | None -> ())
+  ;;
+
+  let rec filter_over
+            ~(state : State.t)
+            ~(env : Env.t)
+            t
+            ~expected_type
+            ~over
+            over_type_p
+            expected_type_p
+    =
+    over_match
+      ~state
+      ~env
+      t
+      ~over
+      expected_type_p
+      ~closure:[ expected_type; over_type_p ]
+      ~with_:(fun ~shape:expected_type_p_shape ~args:expected_type_p_args ->
+        over_match
+          ~state
+          ~env
+          t
+          ~over
+          over_type_p
+          ~closure:([ expected_type ] @ expected_type_p_args)
+          ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
+            if Principal_shape.equal expected_type_p_shape over_type_p_shape
+            then
+              List.iter2_exn
+                expected_type_p_args
+                over_type_p_args
+                ~f:(fun expected_type_p_arg over_type_p_arg ->
+                  filter_over
+                    ~state
+                    ~env
+                    t
+                    ~expected_type
+                    ~over
+                    over_type_p_arg
+                    expected_type_p_arg)
+            else (
+              remove_over t over;
+              unify_if_unique ~state ~env t expected_type)))
+  ;;
+
+  let match_ ~state ~env t ~expected_type =
+    Map.iteri
+      t.remaining_overs
+      ~f:(fun ~key:over ~data:{ over_root; over_handlers = _ } ->
+        filter_over ~state ~env t ~expected_type ~over over_root expected_type)
+  ;;
+end
+
 let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
   fun ~state ~env cst ->
   [%log.global.debug
@@ -210,6 +320,18 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     let actual_gtype = G.instantiate ~state ~curr_region:env.curr_region var_gscheme in
     [%log.global.debug "Scheme instance" (actual_gtype : G.Type.t)];
     unify ~state ~env actual_gtype expected_gtype
+  | Over_instance (vars, expected_type) ->
+    [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
+    let expected_gtype = gtype_of_type ~state ~env expected_type in
+    [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
+    let overs =
+      vars
+      |> List.map ~f:(fun over_var ->
+        let var_gscheme = Env.find_var env over_var in
+        over_var, G.instantiate ~state ~curr_region:env.curr_region var_gscheme)
+    in
+    let switch = Over_switch.create overs in
+    Over_switch.match_ ~state ~env switch ~expected_type:expected_gtype
   | Exists (type_var, cst) ->
     [%log.global.debug "Binding unification for type_var" (type_var : Type.Var.t)];
     let env = exists ~state ~env ~type_var in
@@ -250,7 +372,7 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
       else_ ()
     in
     [%log.global.debug "Suspending match..."];
-    let _ =
+    let _ : Principal_shape.Var.Registered_handler.t option =
       G.Suspended_match.match_or_yield
         ~state
         ~curr_region:env.curr_region

--- a/lib/constraint_solver/solver.ml
+++ b/lib/constraint_solver/solver.ml
@@ -175,49 +175,67 @@ module Over_switch = struct
 
   and over =
     { mutable over_handlers : Principal_shape.Var.Registered_handler.t list
-    ; over_root : G.Type.t
+    ; over_scheme : G.Scheme.t
     }
 
   let create initial_overs =
     { remaining_overs =
         initial_overs
-        |> List.map ~f:(fun (over_var, over_root) ->
-          over_var, { over_root; over_handlers = [] })
+        |> List.map ~f:(fun (over_var, over_scheme) ->
+          over_var, { over_scheme; over_handlers = [] })
         |> Constraint.Var.Map.of_alist_exn
     }
   ;;
 
   let remove_over t over =
     Map.find t.remaining_overs over
-    |> Option.iter ~f:(fun { over_handlers; over_root = _ } ->
+    |> Option.iter ~f:(fun { over_handlers; over_scheme = _ } ->
       List.iter over_handlers ~f:Principal_shape.Var.Registered_handler.cancel_if_pending;
       t.remaining_overs <- Map.remove t.remaining_overs over)
   ;;
 
   let ambiguous t = Map.length t.remaining_overs > 1
 
-  let unify_if_unique ~state ~env t expected_type =
+  let unify_if_unique ~(state : State.t) ~(env : Env.t) t expected_type =
     if ambiguous t
     then ()
     else (
       match Map.to_alist t.remaining_overs with
-      | [ (_over_var, over) ] -> unify ~state ~env over.over_root expected_type
+      | [ (_over_var, over) ] ->
+        let actual_gtype =
+          G.instantiate ~state ~curr_region:env.curr_region over.over_scheme
+        in
+        unify ~state ~env actual_gtype expected_type
       | _ -> assert false)
   ;;
 
-  let over_match ~(state : State.t) ~(env : Env.t) t ~over matchee ~closure ~with_ =
+  let over_match
+        ~(state : State.t)
+        ~(env : Env.t)
+        ~curr_region
+        t
+        ~over
+        matchee
+        ~closure
+        ~with_
+    =
     let range = Option.value_exn ~here:[%here] env.range in
     match Map.find t.remaining_overs over with
     | None ->
       (* overload was already removed, no need to generate any subsequent constraints *)
       ()
     | Some over ->
+      let curr_region =
+        match curr_region with
+        | `Env -> env.curr_region
+        | `Over -> over.over_scheme.region
+      in
       let handler =
         G.Suspended_match.match_or_yield
           ~state
-          ~curr_region:env.curr_region
+          ~curr_region
           { matchee
-          ; closure = { variables = over.over_root :: closure; schemes = [] }
+          ; closure = { variables = closure; schemes = [ over.over_scheme ] }
           ; case = with_
           ; else_ = (fun () -> Omniml_error.(raise @@ ambiguous_overloading ~range))
           ; error = (fun _ -> Omniml_error.ambiguous_overloading ~range)
@@ -240,43 +258,53 @@ module Over_switch = struct
     over_match
       ~state
       ~env
+      ~curr_region:`Env
       t
       ~over
       expected_type_p
-      ~closure:[ expected_type; over_type_p ]
+      ~closure:[ expected_type ]
       ~with_:(fun ~shape:expected_type_p_shape ~args:expected_type_p_args ->
-        over_match
-          ~state
-          ~env
-          t
-          ~over
-          over_type_p
-          ~closure:([ expected_type ] @ expected_type_p_args)
-          ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
-            if Principal_shape.equal expected_type_p_shape over_type_p_shape
-            then
-              List.iter2_exn
-                expected_type_p_args
-                over_type_p_args
-                ~f:(fun expected_type_p_arg over_type_p_arg ->
-                  filter_over
-                    ~state
-                    ~env
-                    t
-                    ~expected_type
-                    ~over
-                    over_type_p_arg
-                    expected_type_p_arg)
-            else (
-              remove_over t over;
-              unify_if_unique ~state ~env t expected_type)))
+        if
+          G.Type.is_generic over_type_p
+          &&
+          match G.Type.inner over_type_p with
+          | Var -> true
+          | _ -> false
+        then ()
+        else
+          over_match
+            ~state
+            ~env
+            ~curr_region:`Over
+            t
+            ~over
+            over_type_p
+            ~closure:([ expected_type ] @ expected_type_p_args)
+            ~with_:(fun ~shape:over_type_p_shape ~args:over_type_p_args ->
+              if Principal_shape.equal expected_type_p_shape over_type_p_shape
+              then
+                List.iter2_exn
+                  expected_type_p_args
+                  over_type_p_args
+                  ~f:(fun expected_type_p_arg over_type_p_arg ->
+                    filter_over
+                      ~state
+                      ~env
+                      t
+                      ~expected_type
+                      ~over
+                      over_type_p_arg
+                      expected_type_p_arg)
+              else (
+                remove_over t over;
+                unify_if_unique ~state ~env t expected_type)))
   ;;
 
   let match_ ~state ~env t ~expected_type =
     Map.iteri
       t.remaining_overs
-      ~f:(fun ~key:over ~data:{ over_root; over_handlers = _ } ->
-        filter_over ~state ~env t ~expected_type ~over over_root expected_type)
+      ~f:(fun ~key:over ~data:{ over_scheme; over_handlers = _ } ->
+        filter_over ~state ~env t ~expected_type ~over over_scheme.root expected_type)
   ;;
 end
 
@@ -324,12 +352,7 @@ let rec solve : state:State.t -> env:Env.t -> Constraint.t -> unit =
     [%log.global.debug "Decoding expected_type" (expected_type : Type.t)];
     let expected_gtype = gtype_of_type ~state ~env expected_type in
     [%log.global.debug "Decoded expected_type" (expected_gtype : G.Type.t)];
-    let overs =
-      vars
-      |> List.map ~f:(fun over_var ->
-        let var_gscheme = Env.find_var env over_var in
-        over_var, G.instantiate ~state ~curr_region:env.curr_region var_gscheme)
-    in
+    let overs = List.map vars ~f:(fun over_var -> over_var, Env.find_var env over_var) in
     let switch = Over_switch.create overs in
     Over_switch.match_ ~state ~env switch ~expected_type:expected_gtype
   | Exists (type_var, cst) ->

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -16,9 +16,9 @@ let match_err _ =
 
 let else_match_err () = assert false
 
-let print_solve_result ?defaulting ?(log_level = `Info) cst =
+let print_solve_result ?defaulting ?termination_check ?(log_level = `Info) cst =
   Async.Log.Global.set_level log_level;
-  let result = Omniml_constraint_solver.solve ?defaulting cst in
+  let result = Omniml_constraint_solver.solve ?defaulting ?termination_check cst in
   match result with
   | Ok () -> print_s [%message "Constraint is satisfiable" (cst : C.t)]
   | Error err ->

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -288,7 +288,7 @@ let%expect_test "No suspended matches results in normal generalization" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
+        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
          (in_
           (Exists ((id 2) (name Type.Var))
            (Exists ((id 3) (name Type.Var))
@@ -297,7 +297,7 @@ let%expect_test "No suspended matches results in normal generalization" =
               (Arrow (Var ((id 2) (name Type.Var)))
                (Var ((id 3) (name Type.Var)))))
              (Let
-              ((type_vars ()) (implicits ()) (in_ True)
+              ((type_vars ()) (in_ True)
                (bindings
                 (((binding_var ((id 7) (name Constraint.Var)))
                   (binding_type (Var ((id 2) (name Type.Var))))))))
@@ -349,7 +349,7 @@ let%expect_test "Partial generic becomes instance" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
+         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
           (in_
            (Match (matchee ((id 0) (name Type.Var)))
             (closure
@@ -397,7 +397,7 @@ let%expect_test "Partial generic becomes generic" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
+        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
          (in_
           (Match (matchee ((id 0) (name Type.Var)))
            (closure ((type_vars (((id 1) (name Type.Var)))) (vars ())))
@@ -467,7 +467,7 @@ let%expect_test "Propagating changes during partial generalization" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
+         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
           (in_
            (Conj
             (Match (matchee ((id 0) (name Type.Var)))
@@ -570,7 +570,7 @@ let%expect_test "Partial ungeneralization (Partial<>Instance)" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
+         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
           (in_
            (Match (matchee ((id 0) (name Type.Var)))
             (closure
@@ -631,10 +631,10 @@ let%expect_test "Partial ungeneralization (Partial<>Partial)" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
+         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
           (in_
            (Let
-            ((type_vars ((Flexible ((id 3) (name Type.Var))))) (implicits ())
+            ((type_vars ((Flexible ((id 3) (name Type.Var)))))
              (in_
               (Match (matchee ((id 0) (name Type.Var)))
                (closure
@@ -699,7 +699,6 @@ let%expect_test "Partials propagate to same instance group" =
         ((type_vars
           ((Flexible ((id 1) (name Type.Var)))
            (Flexible ((id 2) (name Type.Var)))))
-         (implicits ())
          (in_
           (Match (matchee ((id 0) (name Type.Var)))
            (closure
@@ -769,7 +768,6 @@ let%expect_test "Detect SCC cycle accross regions" =
         ((type_vars
           ((Flexible ((id 1) (name Type.Var)))
            (Flexible ((id 2) (name Type.Var)))))
-         (implicits ())
          (in_
           (Conj
            (Conj
@@ -859,7 +857,7 @@ let%expect_test "" =
         (Exists ((id 5) (name Type.Var))
          (Exists ((id 6) (name Type.Var))
           (Let
-           ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
+           ((type_vars ((Flexible ((id 1) (name Type.Var)))))
             (in_
              (Conj
               (Match (matchee ((id 0) (name Type.Var)))
@@ -909,8 +907,7 @@ let%expect_test "" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
-         (in_ True)
+        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (in_ True)
          (bindings
           (((binding_var ((id 2) (name Constraint.Var)))
             (binding_type
@@ -958,10 +955,10 @@ let%expect_test "" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
+        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
          (in_
           (Let
-           ((type_vars ()) (implicits ()) (in_ True)
+           ((type_vars ()) (in_ True)
             (bindings
              (((binding_var ((id 3) (name Constraint.Var)))
                (binding_type (Var ((id 1) (name Type.Var))))))))
@@ -1006,10 +1003,10 @@ let%expect_test "" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
+        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
          (in_
           (Let
-           ((type_vars ()) (implicits ()) (in_ True)
+           ((type_vars ()) (in_ True)
             (bindings
              (((binding_var ((id 3) (name Constraint.Var)))
                (binding_type (Var ((id 1) (name Type.Var))))))))

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -16,9 +16,9 @@ let match_err _ =
 
 let else_match_err () = assert false
 
-let print_solve_result ?defaulting ?termination_check ?(log_level = `Info) cst =
+let print_solve_result ?defaulting ?termination_budget_spec ?(log_level = `Info) cst =
   Async.Log.Global.set_level log_level;
-  let result = Omniml_constraint_solver.solve ?defaulting ?termination_check cst in
+  let result = Omniml_constraint_solver.solve ?defaulting ?termination_budget_spec cst in
   match result with
   | Ok () -> print_s [%message "Constraint is satisfiable" (cst : C.t)]
   | Error err ->

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -268,11 +268,12 @@ let%expect_test "No suspended matches results in normal generalization" =
     @@ let_
          (poly_binding
             ([ Flexible, a2 ]
-             @. (exists a3
-                 @@ exists a4
-                 @@ (T.(var a2 =~ var a3 @-> var a4)
-                     &~ let_ (mono_binding [ xx @: T.var a3 ]) ~in_:(inst xx (T.var a4)))
-                )
+             @. []
+             @?-> (exists a3
+                   @@ exists a4
+                   @@ (T.(var a2 =~ var a3 @-> var a4)
+                       &~ let_ (mono_binding [ xx @: T.var a3 ]) ~in_:(inst xx (T.var a4))
+                      ))
              @=> [ xid @: T.var a2 ]))
          ~in_:
            (exists a5
@@ -332,12 +333,13 @@ let%expect_test "Partial generic becomes instance" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. match_
-                  a1
-                  ~closure:[ `Type a3; `Type a2 ]
-                  ~with_:(fun _ -> T.(var a3 =~ var a2) &~ T.(var a2 =~ tint))
-                  ~else_:else_match_err
-                  ~error:match_err
+             @. []
+             @?-> match_
+                    a1
+                    ~closure:[ `Type a3; `Type a2 ]
+                    ~with_:(fun _ -> T.(var a3 =~ var a2) &~ T.(var a2 =~ tint))
+                    ~else_:else_match_err
+                    ~error:match_err
              @=> [ x1 @: T.var a3 ]))
          ~in_:(inst x1 tint &~ T.(var a1 =~ tstring))
   in
@@ -378,12 +380,13 @@ let%expect_test "Partial generic becomes generic" =
     @@ let_
          (poly_binding
             ([ Flexible, a2 ]
-             @. match_
-                  a1
-                  ~closure:[ `Type a2 ]
-                  ~with_:(fun _ -> exists a3 @@ T.(var a2 =~ var a3 @-> var a3))
-                  ~else_:else_match_err
-                  ~error:match_err
+             @. []
+             @?-> match_
+                    a1
+                    ~closure:[ `Type a2 ]
+                    ~with_:(fun _ -> exists a3 @@ T.(var a2 =~ var a3 @-> var a3))
+                    ~else_:else_match_err
+                    ~error:match_err
              @=> [ x1 @: T.var a2 ]))
          ~in_:
            (inst x1 T.(tint @-> tint)
@@ -430,23 +433,24 @@ let%expect_test "Propagating changes during partial generalization" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. ((* This match forces [a3] to be partially generic *)
-                 match_
-                   a1
-                   ~closure:[ `Type a3 ]
-                   ~with_:(fun _ -> tt)
-                   ~else_:else_match_err
-                   ~error:match_err
-                 &~
-                 (* This match is resolved after [a2] is unified with int.
+             @. []
+             @?-> ((* This match forces [a3] to be partially generic *)
+                   match_
+                     a1
+                     ~closure:[ `Type a3 ]
+                     ~with_:(fun _ -> tt)
+                     ~else_:else_match_err
+                     ~error:match_err
+                   &~
+                   (* This match is resolved after [a2] is unified with int.
                           But since [a3] is still partially generic, the structure of [a3] is
                           not propagated to [a4]. This causes a bug. *)
-                 match_
-                   a2
-                   ~closure:[ `Type a3 ]
-                   ~with_:(fun _ -> T.(var a3 =~ tint))
-                   ~else_:else_match_err
-                   ~error:match_err)
+                   match_
+                     a2
+                     ~closure:[ `Type a3 ]
+                     ~with_:(fun _ -> T.(var a3 =~ tint))
+                     ~else_:else_match_err
+                     ~error:match_err)
              @=> [ x1 @: T.var a3 ]))
          ~in_:
            (exists a4
@@ -553,12 +557,13 @@ let%expect_test "Partial ungeneralization (Partial<>Instance)" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. match_
-                  a1
-                  ~closure:[ `Type a3; `Type a2 ]
-                  ~with_:(fun _ -> T.(var a3 =~ var a2))
-                  ~else_:else_match_err
-                  ~error:match_err
+             @. []
+             @?-> match_
+                    a1
+                    ~closure:[ `Type a3; `Type a2 ]
+                    ~with_:(fun _ -> T.(var a3 =~ var a2))
+                    ~else_:else_match_err
+                    ~error:match_err
              @=> [ x1 @: T.var a3 ]))
          ~in_:(inst x1 tint &~ T.(var a2 =~ tstring) &~ T.(var a1 =~ tint))
   in
@@ -609,17 +614,19 @@ let%expect_test "Partial ungeneralization (Partial<>Partial)" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. let_
-                  (poly_binding
-                     ([ Flexible, a4 ]
-                      @. match_
-                           a1
-                           ~closure:[ `Type a4; `Type a3 ]
-                           ~with_:(fun _ -> T.(var a4 =~ var a3))
-                           ~else_:else_match_err
-                           ~error:match_err
-                      @=> [ x2 @: T.var a4 ]))
-                  ~in_:(inst x2 tint &~ inst x2 tstring)
+             @. []
+             @?-> let_
+                    (poly_binding
+                       ([ Flexible, a4 ]
+                        @. []
+                        @?-> match_
+                               a1
+                               ~closure:[ `Type a4; `Type a3 ]
+                               ~with_:(fun _ -> T.(var a4 =~ var a3))
+                               ~else_:else_match_err
+                               ~error:match_err
+                        @=> [ x2 @: T.var a4 ]))
+                    ~in_:(inst x2 tint &~ inst x2 tstring)
              @=> [ x1 @: T.var a3 ]))
          ~in_:T.(var a1 =~ tstring)
   in
@@ -675,12 +682,13 @@ let%expect_test "Partials propagate to same instance group" =
     @@ let_
          (poly_binding
             ([ Flexible, a2; Flexible, a3 ]
-             @. match_
-                  a1
-                  ~closure:[ `Type a2; `Type a3 ]
-                  ~with_:(fun _ -> T.(var a2 =~ var a3))
-                  ~else_:else_match_err
-                  ~error:match_err
+             @. []
+             @?-> match_
+                    a1
+                    ~closure:[ `Type a2; `Type a3 ]
+                    ~with_:(fun _ -> T.(var a2 =~ var a3))
+                    ~else_:else_match_err
+                    ~error:match_err
              @=> [ (x1 @: T.(var a3 @-> var a2)) ]))
          ~in_:
            (exists_many [ a4; a5 ]
@@ -742,19 +750,20 @@ let%expect_test "Detect SCC cycle accross regions" =
     @@ let_
          (poly_binding
             ([ Flexible, a2; Flexible, a3 ]
-             @. (match_
-                   a2
-                   ~closure:[ `Type a3 ]
-                   ~with_:(fun _ -> tt)
-                   ~else_:else_match_err
-                   ~error:match_err
-                 &~ match_
-                      a3
-                      ~closure:[ `Type a2 ]
-                      ~with_:(fun _ -> tt)
-                      ~else_:else_match_err
-                      ~error:match_err
-                 &~ T.(var a2 =~ var a1))
+             @. []
+             @?-> (match_
+                     a2
+                     ~closure:[ `Type a3 ]
+                     ~with_:(fun _ -> tt)
+                     ~else_:else_match_err
+                     ~error:match_err
+                   &~ match_
+                        a3
+                        ~closure:[ `Type a2 ]
+                        ~with_:(fun _ -> tt)
+                        ~else_:else_match_err
+                        ~error:match_err
+                   &~ T.(var a2 =~ var a1))
              @=> [ (x1 @: T.(var a2 @-> var a3)) ]))
          ~in_:tt
   in
@@ -823,19 +832,20 @@ let%expect_test "" =
     @@ let_
          (poly_binding
             ([ Flexible, a2 ]
-             @. (match_
-                   a1
-                   ~closure:[ `Type a2 ]
-                   ~with_:(fun _ ->
-                     exists_many [ a3; a4 ] @@ T.(var a2 =~ var a3 @-> var a4))
-                   ~else_:else_match_err
-                   ~error:match_err
-                 &~ match_
-                      a5
-                      ~closure:[ `Type a2 ]
-                      ~with_:(fun _ -> T.(var a2 =~ tint @-> tint))
-                      ~else_:else_match_err
-                      ~error:match_err)
+             @. []
+             @?-> (match_
+                     a1
+                     ~closure:[ `Type a2 ]
+                     ~with_:(fun _ ->
+                       exists_many [ a3; a4 ] @@ T.(var a2 =~ var a3 @-> var a4))
+                     ~else_:else_match_err
+                     ~error:match_err
+                   &~ match_
+                        a5
+                        ~closure:[ `Type a2 ]
+                        ~with_:(fun _ -> T.(var a2 =~ tint @-> tint))
+                        ~else_:else_match_err
+                        ~error:match_err)
              @=> [ x1 @: T.var a2 ]))
          ~in_:
            ((* 1. Forces the generalization of x1's region *)
@@ -890,7 +900,11 @@ let%expect_test "" =
   let cst =
     exists a1
     @@ let_
-         (poly_binding @@ [ Flexible, a2 ] @. tt @=> [ (x1 @: T.(var a2 @-> var a2)) ])
+         (poly_binding
+          @@ [ Flexible, a2 ]
+          @. []
+          @?-> tt
+          @=> [ (x1 @: T.(var a2 @-> var a2)) ])
          ~in_:
            (match_
               a1
@@ -936,15 +950,16 @@ let%expect_test "" =
     @@ let_
          (poly_binding
           @@ [ Flexible, a2 ]
-          @. let_
-               (mono_binding [ x2 @: T.var a2 ])
-               ~in_:
-                 (match_
-                    a1
-                    ~closure:[ `Scheme x2 ]
-                    ~with_:(fun _ -> inst x2 tint)
-                    ~else_:else_match_err
-                    ~error:match_err)
+          @. []
+          @?-> let_
+                 (mono_binding [ x2 @: T.var a2 ])
+                 ~in_:
+                   (match_
+                      a1
+                      ~closure:[ `Scheme x2 ]
+                      ~with_:(fun _ -> inst x2 tint)
+                      ~else_:else_match_err
+                      ~error:match_err)
           @=> [ x1 @: T.var a2 ])
          ~in_:T.(var a1 =~ tint)
   in
@@ -984,15 +999,16 @@ let%expect_test "" =
     @@ let_
          (poly_binding
           @@ [ Flexible, a2 ]
-          @. let_
-               (mono_binding [ x2 @: T.var a2 ])
-               ~in_:
-                 (match_
-                    a1
-                    ~closure:[ `Scheme x2 ]
-                    ~with_:(fun _ -> inst x2 tint)
-                    ~else_:else_match_err
-                    ~error:match_err)
+          @. []
+          @?-> let_
+                 (mono_binding [ x2 @: T.var a2 ])
+                 ~in_:
+                   (match_
+                      a1
+                      ~closure:[ `Scheme x2 ]
+                      ~with_:(fun _ -> inst x2 tint)
+                      ~else_:else_match_err
+                      ~error:match_err)
           @=> [ x1 @: T.var a2 ])
          ~in_:T.(var a1 =~ tint &~ inst x1 tstring)
   in

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -268,12 +268,11 @@ let%expect_test "No suspended matches results in normal generalization" =
     @@ let_
          (poly_binding
             ([ Flexible, a2 ]
-             @. []
-             @?-> (exists a3
-                   @@ exists a4
-                   @@ (T.(var a2 =~ var a3 @-> var a4)
-                       &~ let_ (mono_binding [ xx @: T.var a3 ]) ~in_:(inst xx (T.var a4))
-                      ))
+             @. (exists a3
+                 @@ exists a4
+                 @@ (T.(var a2 =~ var a3 @-> var a4)
+                     &~ let_ (mono_binding [ xx @: T.var a3 ]) ~in_:(inst xx (T.var a4)))
+                )
              @=> [ xid @: T.var a2 ]))
          ~in_:
            (exists a5
@@ -333,13 +332,12 @@ let%expect_test "Partial generic becomes instance" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. []
-             @?-> match_
-                    a1
-                    ~closure:[ `Type a3; `Type a2 ]
-                    ~with_:(fun _ -> T.(var a3 =~ var a2) &~ T.(var a2 =~ tint))
-                    ~else_:else_match_err
-                    ~error:match_err
+             @. match_
+                  a1
+                  ~closure:[ `Type a3; `Type a2 ]
+                  ~with_:(fun _ -> T.(var a3 =~ var a2) &~ T.(var a2 =~ tint))
+                  ~else_:else_match_err
+                  ~error:match_err
              @=> [ x1 @: T.var a3 ]))
          ~in_:(inst x1 tint &~ T.(var a1 =~ tstring))
   in
@@ -380,13 +378,12 @@ let%expect_test "Partial generic becomes generic" =
     @@ let_
          (poly_binding
             ([ Flexible, a2 ]
-             @. []
-             @?-> match_
-                    a1
-                    ~closure:[ `Type a2 ]
-                    ~with_:(fun _ -> exists a3 @@ T.(var a2 =~ var a3 @-> var a3))
-                    ~else_:else_match_err
-                    ~error:match_err
+             @. match_
+                  a1
+                  ~closure:[ `Type a2 ]
+                  ~with_:(fun _ -> exists a3 @@ T.(var a2 =~ var a3 @-> var a3))
+                  ~else_:else_match_err
+                  ~error:match_err
              @=> [ x1 @: T.var a2 ]))
          ~in_:
            (inst x1 T.(tint @-> tint)
@@ -433,24 +430,23 @@ let%expect_test "Propagating changes during partial generalization" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. []
-             @?-> ((* This match forces [a3] to be partially generic *)
-                   match_
-                     a1
-                     ~closure:[ `Type a3 ]
-                     ~with_:(fun _ -> tt)
-                     ~else_:else_match_err
-                     ~error:match_err
-                   &~
-                   (* This match is resolved after [a2] is unified with int.
+             @. ((* This match forces [a3] to be partially generic *)
+                 match_
+                   a1
+                   ~closure:[ `Type a3 ]
+                   ~with_:(fun _ -> tt)
+                   ~else_:else_match_err
+                   ~error:match_err
+                 &~
+                 (* This match is resolved after [a2] is unified with int.
                           But since [a3] is still partially generic, the structure of [a3] is
                           not propagated to [a4]. This causes a bug. *)
-                   match_
-                     a2
-                     ~closure:[ `Type a3 ]
-                     ~with_:(fun _ -> T.(var a3 =~ tint))
-                     ~else_:else_match_err
-                     ~error:match_err)
+                 match_
+                   a2
+                   ~closure:[ `Type a3 ]
+                   ~with_:(fun _ -> T.(var a3 =~ tint))
+                   ~else_:else_match_err
+                   ~error:match_err)
              @=> [ x1 @: T.var a3 ]))
          ~in_:
            (exists a4
@@ -557,13 +553,12 @@ let%expect_test "Partial ungeneralization (Partial<>Instance)" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. []
-             @?-> match_
-                    a1
-                    ~closure:[ `Type a3; `Type a2 ]
-                    ~with_:(fun _ -> T.(var a3 =~ var a2))
-                    ~else_:else_match_err
-                    ~error:match_err
+             @. match_
+                  a1
+                  ~closure:[ `Type a3; `Type a2 ]
+                  ~with_:(fun _ -> T.(var a3 =~ var a2))
+                  ~else_:else_match_err
+                  ~error:match_err
              @=> [ x1 @: T.var a3 ]))
          ~in_:(inst x1 tint &~ T.(var a2 =~ tstring) &~ T.(var a1 =~ tint))
   in
@@ -614,19 +609,17 @@ let%expect_test "Partial ungeneralization (Partial<>Partial)" =
     @@ let_
          (poly_binding
             ([ Flexible, a3 ]
-             @. []
-             @?-> let_
-                    (poly_binding
-                       ([ Flexible, a4 ]
-                        @. []
-                        @?-> match_
-                               a1
-                               ~closure:[ `Type a4; `Type a3 ]
-                               ~with_:(fun _ -> T.(var a4 =~ var a3))
-                               ~else_:else_match_err
-                               ~error:match_err
-                        @=> [ x2 @: T.var a4 ]))
-                    ~in_:(inst x2 tint &~ inst x2 tstring)
+             @. let_
+                  (poly_binding
+                     ([ Flexible, a4 ]
+                      @. match_
+                           a1
+                           ~closure:[ `Type a4; `Type a3 ]
+                           ~with_:(fun _ -> T.(var a4 =~ var a3))
+                           ~else_:else_match_err
+                           ~error:match_err
+                      @=> [ x2 @: T.var a4 ]))
+                  ~in_:(inst x2 tint &~ inst x2 tstring)
              @=> [ x1 @: T.var a3 ]))
          ~in_:T.(var a1 =~ tstring)
   in
@@ -682,13 +675,12 @@ let%expect_test "Partials propagate to same instance group" =
     @@ let_
          (poly_binding
             ([ Flexible, a2; Flexible, a3 ]
-             @. []
-             @?-> match_
-                    a1
-                    ~closure:[ `Type a2; `Type a3 ]
-                    ~with_:(fun _ -> T.(var a2 =~ var a3))
-                    ~else_:else_match_err
-                    ~error:match_err
+             @. match_
+                  a1
+                  ~closure:[ `Type a2; `Type a3 ]
+                  ~with_:(fun _ -> T.(var a2 =~ var a3))
+                  ~else_:else_match_err
+                  ~error:match_err
              @=> [ (x1 @: T.(var a3 @-> var a2)) ]))
          ~in_:
            (exists_many [ a4; a5 ]
@@ -751,20 +743,19 @@ let%expect_test "Detect SCC cycle accross regions" =
     @@ let_
          (poly_binding
             ([ Flexible, a2; Flexible, a3 ]
-             @. []
-             @?-> (match_
-                     a2
-                     ~closure:[ `Type a3 ]
-                     ~with_:(fun _ -> tt)
-                     ~else_:else_match_err
-                     ~error:match_err
-                   &~ match_
-                        a3
-                        ~closure:[ `Type a2 ]
-                        ~with_:(fun _ -> tt)
-                        ~else_:else_match_err
-                        ~error:match_err
-                   &~ T.(var a2 =~ var a1))
+             @. (match_
+                   a2
+                   ~closure:[ `Type a3 ]
+                   ~with_:(fun _ -> tt)
+                   ~else_:else_match_err
+                   ~error:match_err
+                 &~ match_
+                      a3
+                      ~closure:[ `Type a2 ]
+                      ~with_:(fun _ -> tt)
+                      ~else_:else_match_err
+                      ~error:match_err
+                 &~ T.(var a2 =~ var a1))
              @=> [ (x1 @: T.(var a2 @-> var a3)) ]))
          ~in_:tt
   in
@@ -834,20 +825,19 @@ let%expect_test "" =
     @@ let_
          (poly_binding
             ([ Flexible, a2 ]
-             @. []
-             @?-> (match_
-                     a1
-                     ~closure:[ `Type a2 ]
-                     ~with_:(fun _ ->
-                       exists_many [ a3; a4 ] @@ T.(var a2 =~ var a3 @-> var a4))
-                     ~else_:else_match_err
-                     ~error:match_err
-                   &~ match_
-                        a5
-                        ~closure:[ `Type a2 ]
-                        ~with_:(fun _ -> T.(var a2 =~ tint @-> tint))
-                        ~else_:else_match_err
-                        ~error:match_err)
+             @. (match_
+                   a1
+                   ~closure:[ `Type a2 ]
+                   ~with_:(fun _ ->
+                     exists_many [ a3; a4 ] @@ T.(var a2 =~ var a3 @-> var a4))
+                   ~else_:else_match_err
+                   ~error:match_err
+                 &~ match_
+                      a5
+                      ~closure:[ `Type a2 ]
+                      ~with_:(fun _ -> T.(var a2 =~ tint @-> tint))
+                      ~else_:else_match_err
+                      ~error:match_err)
              @=> [ x1 @: T.var a2 ]))
          ~in_:
            ((* 1. Forces the generalization of x1's region *)
@@ -902,11 +892,7 @@ let%expect_test "" =
   let cst =
     exists a1
     @@ let_
-         (poly_binding
-          @@ [ Flexible, a2 ]
-          @. []
-          @?-> tt
-          @=> [ (x1 @: T.(var a2 @-> var a2)) ])
+         (poly_binding @@ [ Flexible, a2 ] @. tt @=> [ (x1 @: T.(var a2 @-> var a2)) ])
          ~in_:
            (match_
               a1
@@ -953,16 +939,15 @@ let%expect_test "" =
     @@ let_
          (poly_binding
           @@ [ Flexible, a2 ]
-          @. []
-          @?-> let_
-                 (mono_binding [ x2 @: T.var a2 ])
-                 ~in_:
-                   (match_
-                      a1
-                      ~closure:[ `Scheme x2 ]
-                      ~with_:(fun _ -> inst x2 tint)
-                      ~else_:else_match_err
-                      ~error:match_err)
+          @. let_
+               (mono_binding [ x2 @: T.var a2 ])
+               ~in_:
+                 (match_
+                    a1
+                    ~closure:[ `Scheme x2 ]
+                    ~with_:(fun _ -> inst x2 tint)
+                    ~else_:else_match_err
+                    ~error:match_err)
           @=> [ x1 @: T.var a2 ])
          ~in_:T.(var a1 =~ tint)
   in
@@ -1002,16 +987,15 @@ let%expect_test "" =
     @@ let_
          (poly_binding
           @@ [ Flexible, a2 ]
-          @. []
-          @?-> let_
-                 (mono_binding [ x2 @: T.var a2 ])
-                 ~in_:
-                   (match_
-                      a1
-                      ~closure:[ `Scheme x2 ]
-                      ~with_:(fun _ -> inst x2 tint)
-                      ~else_:else_match_err
-                      ~error:match_err)
+          @. let_
+               (mono_binding [ x2 @: T.var a2 ])
+               ~in_:
+                 (match_
+                    a1
+                    ~closure:[ `Scheme x2 ]
+                    ~with_:(fun _ -> inst x2 tint)
+                    ~else_:else_match_err
+                    ~error:match_err)
           @=> [ x1 @: T.var a2 ])
          ~in_:T.(var a1 =~ tint &~ inst x1 tstring)
   in

--- a/lib/constraint_solver/test/test_constraint_solver.ml
+++ b/lib/constraint_solver/test/test_constraint_solver.ml
@@ -289,7 +289,7 @@ let%expect_test "No suspended matches results in normal generalization" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
+        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
          (in_
           (Exists ((id 2) (name Type.Var))
            (Exists ((id 3) (name Type.Var))
@@ -298,7 +298,7 @@ let%expect_test "No suspended matches results in normal generalization" =
               (Arrow (Var ((id 2) (name Type.Var)))
                (Var ((id 3) (name Type.Var)))))
              (Let
-              ((type_vars ()) (in_ True)
+              ((type_vars ()) (implicits ()) (in_ True)
                (bindings
                 (((binding_var ((id 7) (name Constraint.Var)))
                   (binding_type (Var ((id 2) (name Type.Var))))))))
@@ -351,7 +351,7 @@ let%expect_test "Partial generic becomes instance" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
+         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
           (in_
            (Match (matchee ((id 0) (name Type.Var)))
             (closure
@@ -400,7 +400,7 @@ let%expect_test "Partial generic becomes generic" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
+        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
          (in_
           (Match (matchee ((id 0) (name Type.Var)))
            (closure ((type_vars (((id 1) (name Type.Var)))) (vars ())))
@@ -471,7 +471,7 @@ let%expect_test "Propagating changes during partial generalization" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
+         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
           (in_
            (Conj
             (Match (matchee ((id 0) (name Type.Var)))
@@ -575,7 +575,7 @@ let%expect_test "Partial ungeneralization (Partial<>Instance)" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
+         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
           (in_
            (Match (matchee ((id 0) (name Type.Var)))
             (closure
@@ -638,10 +638,10 @@ let%expect_test "Partial ungeneralization (Partial<>Partial)" =
       (Exists ((id 0) (name Type.Var))
        (Exists ((id 1) (name Type.Var))
         (Let
-         ((type_vars ((Flexible ((id 2) (name Type.Var)))))
+         ((type_vars ((Flexible ((id 2) (name Type.Var))))) (implicits ())
           (in_
            (Let
-            ((type_vars ((Flexible ((id 3) (name Type.Var)))))
+            ((type_vars ((Flexible ((id 3) (name Type.Var))))) (implicits ())
              (in_
               (Match (matchee ((id 0) (name Type.Var)))
                (closure
@@ -707,6 +707,7 @@ let%expect_test "Partials propagate to same instance group" =
         ((type_vars
           ((Flexible ((id 1) (name Type.Var)))
            (Flexible ((id 2) (name Type.Var)))))
+         (implicits ())
          (in_
           (Match (matchee ((id 0) (name Type.Var)))
            (closure
@@ -777,6 +778,7 @@ let%expect_test "Detect SCC cycle accross regions" =
         ((type_vars
           ((Flexible ((id 1) (name Type.Var)))
            (Flexible ((id 2) (name Type.Var)))))
+         (implicits ())
          (in_
           (Conj
            (Conj
@@ -867,7 +869,7 @@ let%expect_test "" =
         (Exists ((id 5) (name Type.Var))
          (Exists ((id 6) (name Type.Var))
           (Let
-           ((type_vars ((Flexible ((id 1) (name Type.Var)))))
+           ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
             (in_
              (Conj
               (Match (matchee ((id 0) (name Type.Var)))
@@ -921,7 +923,8 @@ let%expect_test "" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (in_ True)
+        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
+         (in_ True)
          (bindings
           (((binding_var ((id 2) (name Constraint.Var)))
             (binding_type
@@ -970,10 +973,10 @@ let%expect_test "" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
+        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
          (in_
           (Let
-           ((type_vars ()) (in_ True)
+           ((type_vars ()) (implicits ()) (in_ True)
             (bindings
              (((binding_var ((id 3) (name Constraint.Var)))
                (binding_type (Var ((id 1) (name Type.Var))))))))
@@ -1019,10 +1022,10 @@ let%expect_test "" =
      (cst
       (Exists ((id 0) (name Type.Var))
        (Let
-        ((type_vars ((Flexible ((id 1) (name Type.Var)))))
+        ((type_vars ((Flexible ((id 1) (name Type.Var))))) (implicits ())
          (in_
           (Let
-           ((type_vars ()) (in_ True)
+           ((type_vars ()) (implicits ()) (in_ True)
             (bindings
              (((binding_var ((id 3) (name Constraint.Var)))
                (binding_type (Var ((id 1) (name Type.Var))))))))

--- a/lib/constraint_solver/tree.mli
+++ b/lib/constraint_solver/tree.mli
@@ -14,8 +14,8 @@ module Node : sig
     { id : Identifier.t (** Unique identifier of the node *)
     ; level : Level.t
       (** The level of the node in the tree.
-      If [parent] is [None], then [level = Level.zero],
-      otherwise [level = Level.succ parent.level]. *)
+          If [parent] is [None], then [level = Level.zero],
+          otherwise [level = Level.succ parent.level]. *)
     ; value : 'a (** The region of the node *)
     ; parent : 'a t option (** Parent of the node, if [None] then node is a root node. *)
     }

--- a/lib/constraint_solver/type.ml
+++ b/lib/constraint_solver/type.ml
@@ -6,6 +6,7 @@ module Var = Self.Var
 type t = Self.t =
   | Var of Var.t
   | Arrow of t * t
+  | Implicit_arrow of t * t
   | Tuple of t list
   | Constr of t list * Ident.t
   | Shape of t list * Types.Principal_shape.t
@@ -14,6 +15,7 @@ type t = Self.t =
 
 let var v = Var v
 let ( @-> ) t1 t2 = Arrow (t1, t2)
+let ( @=> ) t1 t2 = Implicit_arrow (t1, t2)
 let constr ts constr = Constr (ts, constr)
 
 let tuple ts =
@@ -38,6 +40,7 @@ end
 module Matchee = struct
   type t =
     | Arrow of Var.t * Var.t
+    | Implicit_arrow of Var.t * Var.t
     | Tuple of Var.t list
     | Constr of Var.t list * Ident.t
     | Poly of Scheme.t

--- a/lib/constraint_solver/types.ml
+++ b/lib/constraint_solver/types.ml
@@ -19,6 +19,7 @@ module rec Type : sig
   type t =
     | Var of Var.t (** Type variable ['a] *)
     | Arrow of t * t (** Function types [tua1 -> tau2] *)
+    | Implicit_arrow of t * t (** Implicit function types [tau1 => tau2] *)
     | Tuple of t list (** Tuple types [tau1 * ... * taun] *)
     | Constr of t list * Ident.t (** Nominal types [(tau1, ..., taun) T] *)
     | Shape of t list * Principal_shape.t (** Applied shape [(tau1, ..., taun) s] *)
@@ -41,6 +42,7 @@ end = struct
   type t =
     | Var of Var.t (** Type variable ['a] *)
     | Arrow of t * t (** Function types [tua1 -> tau2] *)
+    | Implicit_arrow of t * t (** Implicit function types [tau1 => tau2] *)
     | Tuple of t list (** Tuple types [tau1 * ... * taun] *)
     | Constr of t list * Ident.t (** Nominal types [(tau1, ..., taun) T] *)
     | Shape of t list * Principal_shape.t (** Applied shape [(tau1, ..., taun) s] *)
@@ -68,6 +70,7 @@ and Principal_shape : sig
 
   type t =
     | Sh_arrow (** Arrow shape ['c1 'c2. 'c1 -> 'c2] *)
+    | Sh_implicit_arrow (** Implicit arrow shape ['c1 'c2. 'c1 => 'c2] *)
     | Sh_tuple of int (** Tuple shape ['c1, ..., 'cn. 'c1 * ... * 'cn] *)
     | Sh_constr of int * Type.Ident.t
     (** Nominal type shape ['c1, ..., 'cn. ('c1, ..., 'cn) T] *)
@@ -84,6 +87,7 @@ end = struct
 
   type t =
     | Sh_arrow (** Arrow shape ['c1 'c2. 'c1 -> 'c2] *)
+    | Sh_implicit_arrow (** Implicit arrow shape ['c1 'c2. 'c1 => 'c2] *)
     | Sh_tuple of int (** Tuple shape ['c1, ..., 'cn. 'c1 * ... * 'cn] *)
     | Sh_constr of int * Type.Ident.t
     (** Nominal type shape ['c1, ..., 'cn. ('c1, ..., 'cn) T] *)

--- a/lib/error/omniml_error.ml
+++ b/lib/error/omniml_error.ml
@@ -22,6 +22,7 @@ module Code = struct
     | Projection_out_of_bounds
     | Ambiguous_tuple
     | Ambiguous_polytype
+    | Ambiguous_overloading
     | Unknown
   [@@deriving sexp]
 
@@ -42,6 +43,7 @@ module Code = struct
     | Projection_out_of_bounds -> "E014"
     | Ambiguous_tuple -> "E015"
     | Ambiguous_polytype -> "E016"
+    | Ambiguous_overloading -> "E017"
     | Unknown -> "E???"
   ;;
 end
@@ -135,6 +137,17 @@ let unbound_variable ~range (var_name : Var_name.t) : t =
        "cannot find value %a in this scope"
        pp_quoted_s
        (var_name :> string)
+;;
+
+let unbound_over_path (over_path : Over_path.t) : t =
+  singleton
+  @@ Diagnostic.createf
+       ~labels:[ not_found_in_this_scope_label ~range:over_path.range ]
+       ~code:Code.Unbound_variable
+       Error
+       "cannot find value %a in this scope"
+       (pp_quoted Over_path.pp)
+       over_path
 ;;
 
 let unbound_type ~range (type_name : Type_name.t) : t =
@@ -336,6 +349,17 @@ let ambiguous_constructor ~range =
        ~code:Code.Ambiguous_constructor
        Error
        "ambiguous constructor"
+;;
+
+let ambiguous_overloading ~range =
+  let open Diagnostic in
+  singleton
+  @@ Diagnostic.createf
+       ~labels:[ empty_primary_label ~range ]
+       ~notes:[ Message.createf "hint: add a type annotation" ]
+       ~code:Code.Ambiguous_overloading
+       Error
+       "ambiguous overloading"
 ;;
 
 let rigid_variable_escape ~range =

--- a/lib/error/omniml_error.ml
+++ b/lib/error/omniml_error.ml
@@ -23,6 +23,7 @@ module Code = struct
     | Ambiguous_tuple
     | Ambiguous_polytype
     | Ambiguous_overloading
+    | Resolution_termination_check_failed
     | Unknown
   [@@deriving sexp]
 
@@ -44,6 +45,7 @@ module Code = struct
     | Ambiguous_tuple -> "E015"
     | Ambiguous_polytype -> "E016"
     | Ambiguous_overloading -> "E017"
+    | Resolution_termination_check_failed -> "E018"
     | Unknown -> "E???"
   ;;
 end
@@ -419,6 +421,16 @@ let ambiguous_polytype ~range =
        ~code:Code.Ambiguous_polytype
        Error
        "unknown polytype"
+;;
+
+let resolution_termination_check_failed ~range =
+  singleton
+  @@ Diagnostic.createf
+       ~labels:[ empty_primary_label ~range ]
+       ~notes:[]
+       ~code:Code.Resolution_termination_check_failed
+       Error
+       "resolution failed to terminate"
 ;;
 
 module For_testing = struct

--- a/lib/error/omniml_error.ml
+++ b/lib/error/omniml_error.ml
@@ -302,6 +302,7 @@ let disambiguation_mismatched_type ~range ~type_head =
     match type_head with
     | `Tuple -> "tuple"
     | `Arrow -> "function type"
+    | `Implicit_arrow -> "implicit function type"
     | `Poly -> "polymorphic type"
   in
   singleton
@@ -332,6 +333,7 @@ let disambiguation_tuple_mismatched_type ~range ~type_head =
     match type_head with
     | `Constr -> "type constructor"
     | `Arrow -> "function type"
+    | `Implicit_arrow -> "implicit function type"
     | `Poly -> "polymorphic type"
   in
   singleton
@@ -390,6 +392,7 @@ let polytype_mismatched_type ~range ~type_head =
     match type_head with
     | `Tuple -> "tuple"
     | `Arrow -> "function type"
+    | `Implicit_arrow -> "implicit function type"
     | `Constr -> "type constructor"
   in
   singleton

--- a/lib/error/omniml_error.mli
+++ b/lib/error/omniml_error.mli
@@ -86,6 +86,7 @@ val polytype_mismatched_type
 
 val ambiguous_tuple : range:Range.t -> t
 val ambiguous_polytype : range:Range.t -> t
+val resolution_termination_check_failed : range:Range.t -> t
 
 module For_testing : sig
   val use_expect_test_config : unit -> unit

--- a/lib/error/omniml_error.mli
+++ b/lib/error/omniml_error.mli
@@ -35,6 +35,7 @@ val unterminated_comment : range:Range.t -> t
 val unknown_start_of_token : range:Range.t -> char -> t
 val syntax_error : range:Range.t -> t
 val unbound_variable : range:Range.t -> Var_name.t -> t
+val unbound_over_path : Over_path.t -> t
 val unbound_type : range:Range.t -> Type_name.t -> t
 val unbound_type_variable : range:Range.t -> Type_var_name.t -> t
 val unbound_constructor : range:Range.t -> Constructor_name.t -> t
@@ -62,6 +63,7 @@ val constructor_arity_mismatch
 val mismatched_type : range:Range.t -> pp_type:'a Fmt.t -> 'a -> 'a -> t
 
 val ambiguous_constructor : range:Range.t -> t
+val ambiguous_overloading : range:Range.t -> t
 
 val disambiguation_mismatched_type
   :  range:Range.t

--- a/lib/error/omniml_error.mli
+++ b/lib/error/omniml_error.mli
@@ -67,12 +67,12 @@ val ambiguous_overloading : range:Range.t -> t
 
 val disambiguation_mismatched_type
   :  range:Range.t
-  -> type_head:[ `Tuple | `Arrow | `Poly ]
+  -> type_head:[ `Tuple | `Arrow | `Implicit_arrow | `Poly ]
   -> t
 
 val disambiguation_tuple_mismatched_type
   :  range:Range.t
-  -> type_head:[ `Constr | `Arrow | `Poly ]
+  -> type_head:[ `Constr | `Arrow | `Implicit_arrow | `Poly ]
   -> t
 
 val projection_out_of_bounds : range:Range.t -> arity:int -> index:int -> t
@@ -81,7 +81,7 @@ val rigid_variable_escape : range:Range.t -> t
 
 val polytype_mismatched_type
   :  range:Range.t
-  -> type_head:[ `Tuple | `Arrow | `Constr ]
+  -> type_head:[ `Tuple | `Arrow | `Implicit_arrow | `Constr ]
   -> t
 
 val ambiguous_tuple : range:Range.t -> t

--- a/lib/main/omniml_main.ml
+++ b/lib/main/omniml_main.ml
@@ -48,6 +48,7 @@ let type_check_and_print
       ~with_stdlib
       ~with_poly_params
       ~defaulting
+      ~termination_check
   =
   Omniml_error.handle_uncaught ~exit:false
   @@ fun () ->
@@ -60,6 +61,6 @@ let type_check_and_print
       >>| fun source ->
       Range.create ~source Byte_index.initial (Byte_index.of_int @@ Source.length source))
   in
-  Omniml_type_checker.check ~defaulting ?range cst;
+  Omniml_type_checker.check ~defaulting ~termination_check ?range cst;
   Fmt.pr "Well typed :)@."
 ;;

--- a/lib/main/omniml_main.mli
+++ b/lib/main/omniml_main.mli
@@ -36,4 +36,5 @@ val type_check_and_print
   -> with_stdlib:bool
   -> with_poly_params:bool
   -> defaulting:Options.Defaulting.t
+  -> termination_check:Options.Termination_check.t
   -> unit

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -3873,3 +3873,110 @@ let%expect_test "" =
         │                 ^^^^^^
     |}]
 ;;
+
+let%expect_test "" =
+  let test = Incremental_test.create ~initial:include_string type_check_and_print in
+  let do_test = Incremental_test.run test in
+  do_test
+    ~add:true
+    {|
+      (* Define [incr] name *)
+      type 'a incr = Incr of 'a;;
+      let val_incr = fun x -> Incr x;;
+      let use_incr = fun x -> match x with (Incr v -> v);;
+      let incr = fun ?x -> use_incr x;;
+
+      (* let incr!int x = x + 1 *)
+      let incr_int = fun x -> x + 1;;
+      let incr_int' = val_incr incr_int;;
+      let implicit incr_int';;
+
+      (* let incr!bool x = not x *)
+      let incr_bool = fun x -> if x then false else true;;
+      let incr_bool' = val_incr incr_bool;;
+      let implicit incr_bool';;
+
+      (* Define [show] name *)
+      type 'a show = Show of 'a;;
+      let val_show = fun x -> Show x;;
+      let use_show = fun x -> match x with (Show v -> v);;
+      let show = fun? x -> use_show x;;
+
+      external show_int : int -> string;;
+      external show_bool : bool -> string;;
+
+      (* let show!int = show_int *)
+      let show_int' = val_show show_int;;
+      let implicit show_int';;
+
+      (* let show!bool = show_bool *)
+      let show_bool= val_show show_bool;;
+      let implicit show_bool;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let one = show (incr 0);;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let show_incr = fun x -> show (incr x);;
+    |};
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:41:38
+     41 │        let show_incr = fun x -> show (incr x);;
+        │                                       ^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:41:32
+     41 │        let show_incr = fun x -> show (incr x);;
+        │                                 ^^^^
+        = hint: add a type annotation
+    |}];
+  do_test
+    ~add:true
+    {|
+      let show_incr = fun? show incr -> 
+        let show = use_show show in
+        let incr = use_incr incr in
+        fun x -> show (incr x)
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let two = show_incr 1;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    ~add:true
+    {|
+      let show_tuple = 
+        fun show_a show_b -> 
+          let show_a = use_show show_a in
+          let show_b = use_show show_b in
+          fun (fst, snd) -> 
+            concat_string (show_a fst) (show_b snd)
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    ~add:true
+    {|
+      let show_tuple' = fun? show_a show_b -> 
+        val_show (show_tuple show_a show_b)
+      ;;
+
+      let implicit show_tuple';;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let onetrue = show (1, true);;
+    |};
+  [%expect {| Well typed :) |}]
+;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -3835,3 +3835,39 @@ let%expect_test "" =
         │                                                              `'b`
     |}]
 ;;
+
+let%expect_test "" =
+  (* Check that implicit resolution terminates. It constructs a 
+     pathological implicit function:
+
+     {[ 
+       val bad : 'a list list => 'a list 
+     ]} 
+
+     Since this is unique in the implicit environment, OmniML will select [bad]
+     for resolution. As a result, it will try to resolve `'a list list`, 
+     which will [bad] again, and so on.
+  *)
+  let str =
+    include_list
+    ^ {|
+      let bad = 
+        fun? self -> exists (type 'a) -> 
+        let _ = (self : 'a list list) in (Nil : 'a list)
+      ;;
+
+      let implicit bad;;
+
+      let summon = fun? x -> x;;
+      let _ = (summon : int list);;
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E018]: resolution failed to terminate
+        ┌─ expect_test.ml:17:16
+     17 │        let _ = (summon : int list);;
+        │                 ^^^^^^
+    |}]
+;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -3864,12 +3864,73 @@ let%expect_test "" =
       let _ = (summon : int list);;
     |}
   in
-  type_check_and_print str;
+  (* Threshold below termination pressure *)
+  type_check_and_print ~termination_check:(Threshold 128) str;
   [%expect
     {|
     error[E018]: resolution failed to terminate
         ┌─ expect_test.ml:17:16
      17 │        let _ = (summon : int list);;
+        │                 ^^^^^^
+    |}];
+  (* Threshold above termination pressure *)
+  type_check_and_print ~termination_check:(Threshold 512) str;
+  [%expect
+    {|
+    error[E018]: resolution failed to terminate
+        ┌─ expect_test.ml:17:16
+     17 │        let _ = (summon : int list);;
+        │                 ^^^^^^
+    |}];
+  (* Decreasing instantiations check *)
+  type_check_and_print ~termination_check:Decreasing_instantiations str;
+  [%expect
+    {|
+    error[E018]: resolution failed to terminate
+        ┌─ expect_test.ml:17:16
+     17 │        let _ = (summon : int list);;
+        │                 ^^^^^^
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_list
+    ^ {|
+      let bad0 = 
+        fun? (_ : int list list) -> (Nil : int list)
+      ;;
+
+      let bad1 = 
+        fun? (_ : int list list list) -> (Nil : int list list)
+      ;;
+
+      let bad2 = 
+        fun? (_ : int list list list list) -> (Nil : int list list list)
+      ;;
+
+      let bad3 = 
+        (Nil : int list list list list)
+      ;;
+
+      let implicit bad0;;
+      let implicit bad1;;
+      let implicit bad2;;
+      let implicit bad3;;
+
+      let summon = fun? x -> x;;
+      let _ = (summon : int list);;
+    |}
+  in
+  (* The expected solution should be (bad0 (bad1 (bad2 bad3))). 
+     But this exceeds the threshold of [2] (it requires 3). 
+     As a result, resolution should fail to terminate (despite terminating) *)
+  type_check_and_print ~termination_check:(Threshold 2) str;
+  [%expect
+    {|
+    error[E018]: resolution failed to terminate
+        ┌─ expect_test.ml:31:16
+     31 │        let _ = (summon : int list);;
         │                 ^^^^^^
     |}]
 ;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -3375,12 +3375,6 @@ let%expect_test "" =
      64 │        let ambig = add;;
         │                    ^^^
         = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:64:19
-     64 │        let ambig = add;;
-        │                    ^^^
-        = hint: add a type annotation
     |}];
   do_test
     {|
@@ -3541,57 +3535,15 @@ let%expect_test "" =
         = hint: add a type annotation
 
     error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:31:15
-     31 │        let z = add x y;;
-        │                ^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
         ┌─ expect_test.ml:31:21
      31 │        let z = add x y;;
         │                      ^
         = hint: add a type annotation
 
     error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:31:21
-     31 │        let z = add x y;;
-        │                      ^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:31:15
-     31 │        let z = add x y;;
-        │                ^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:31:15
-     31 │        let z = add x y;;
-        │                ^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
         ┌─ expect_test.ml:31:19
      31 │        let z = add x y;;
         │                    ^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:31:19
-     31 │        let z = add x y;;
-        │                    ^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:31:15
-     31 │        let z = add x y;;
-        │                ^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:31:15
-     31 │        let z = add x y;;
-        │                ^^^
         = hint: add a type annotation
     |}]
 ;;
@@ -3615,36 +3567,6 @@ let%expect_test "" =
   type_check_and_print str;
   [%expect
     {|
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:12:24
-     12 │        let z = fun x -> foo_bar x x;;
-        │                         ^^^^^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:12:24
-     12 │        let z = fun x -> foo_bar x x;;
-        │                         ^^^^^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:12:24
-     12 │        let z = fun x -> foo_bar x x;;
-        │                         ^^^^^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:12:24
-     12 │        let z = fun x -> foo_bar x x;;
-        │                         ^^^^^^^
-        = hint: add a type annotation
-
-    error[E017]: ambiguous overloading
-        ┌─ expect_test.ml:12:24
-     12 │        let z = fun x -> foo_bar x x;;
-        │                         ^^^^^^^
-        = hint: add a type annotation
-
     error[E017]: ambiguous overloading
         ┌─ expect_test.ml:12:24
      12 │        let z = fun x -> foo_bar x x;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -1033,7 +1033,7 @@ let%expect_test "" =
     Generated constraint:
     (With_range
      (Let
-      ((type_vars ((Flexible ((id 0) (name Type.Var))))) (implicits ())
+      ((type_vars ((Flexible ((id 0) (name Type.Var)))))
        (in_
         (Conj
          (With_range
@@ -1050,12 +1050,13 @@ let%expect_test "" =
                  (Reader
                   ((id 0) (name (expect_test.ml)) (length 34) (unsafe_get <fun>))))))
               (Let
-               ((type_vars ()) (implicits ()) (in_ True)
+               ((type_vars ()) (in_ True)
                 (bindings
                  (((binding_var ((id 3) (name x)))
                    (binding_type (Var ((id 1) (name Type.Var))))))))
                (With_range
-                (Instance ((id 3) (name x)) (Var ((id 2) (name Type.Var))))
+                (Conj (Instance ((id 3) (name x)) (Var ((id 2) (name Type.Var))))
+                 True)
                 ((start 25) (stop 26)
                  (source
                   (Reader
@@ -3223,7 +3224,8 @@ let%expect_test "" =
     |}]
 ;;
 
-let%expect_test "" =
+(*
+   let%expect_test "" =
   let str =
     {|
       let x = 1;;
@@ -3242,14 +3244,17 @@ let%expect_test "" =
   type_check_and_print str;
   [%expect {| Well typed :) |}]
 ;;
+*)
 
-let include_array =
+(*
+   let include_array =
   {|
     type 'a array;; 
 
     external map_array : 'a 'b. ('a -> 'b) -> 'a array -> 'b array;;
   |}
 ;;
+*)
 
 let include_float =
   {|
@@ -3279,7 +3284,8 @@ let include_string =
   |}
 ;;
 
-let%expect_test "" =
+(*
+   let%expect_test "" =
   let test =
     Incremental_test.create
       ~initial:
@@ -3578,6 +3584,7 @@ let%expect_test "" =
         = hint: add a type annotation
     |}]
 ;;
+*)
 
 let%expect_test "" =
   let str =
@@ -3606,7 +3613,7 @@ let%expect_test "" =
       let f = fun? x -> x;;
       let value = 10;;
       let implicit value;;
-      let result = f;;
+      let result = (f : int);;
     |}
   in
   type_check_and_print str;
@@ -3753,7 +3760,7 @@ let%expect_test "" =
          ^ include_monoid_int
          ^ include_monoid_float
          ^ include_monoid_string)
-      type_check_and_print
+      (type_check_and_print ~termination_check:(Threshold 128))
   in
   let do_test = Incremental_test.run test in
   do_test

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -1031,7 +1031,7 @@ let%expect_test "" =
     Generated constraint:
     (With_range
      (Let
-      ((type_vars ((Flexible ((id 0) (name Type.Var)))))
+      ((type_vars ((Flexible ((id 0) (name Type.Var))))) (implicits ())
        (in_
         (Conj
          (With_range
@@ -1048,7 +1048,7 @@ let%expect_test "" =
                  (Reader
                   ((id 0) (name (expect_test.ml)) (length 34) (unsafe_get <fun>))))))
               (Let
-               ((type_vars ()) (in_ True)
+               ((type_vars ()) (implicits ()) (in_ True)
                 (bindings
                  (((binding_var ((id 3) (name x)))
                    (binding_type (Var ((id 1) (name Type.Var))))))))

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -48,6 +48,8 @@ let include_list =
       | Nil
       | Cons of 'a * 'a list
     ;;
+
+    external map_list : 'a 'b. ('a -> 'b) -> 'a list -> 'b list;;
   |}
 ;;
 
@@ -1924,8 +1926,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:25:27
-     25 │        let xignore = poly1 [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:27:27
+     27 │        let xignore = poly1 [(fun x -> x + 1)];;
         │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                 is not equal to
         │                                               `'a -> 'a`
@@ -1956,8 +1958,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E012]: generic type variable escapes its scope
-        ┌─ expect_test.ml:28:35
-     28 │        let escape = fun f -> poly1 [(fun x -> f x; x)];;
+        ┌─ expect_test.ml:30:35
+     30 │        let escape = fun f -> poly1 [(fun x -> f x; x)];;
         │                                    ^^^^^^^^^^^^^^^^^^^
     |}];
   do_test
@@ -1981,8 +1983,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:33:27
-     33 │        let xignore = poly2 [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:35:27
+     35 │        let xignore = poly2 [(fun x -> x + 1)];;
         │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                 is not equal to
         │                                               `'a -> 'a`
@@ -2011,8 +2013,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:41:27
-     41 │        let xignore = poly3 [(fun x -> x + 1)] [8];;
+        ┌─ expect_test.ml:43:27
+     43 │        let xignore = poly3 [(fun x -> x + 1)] [8];;
         │                            ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                 is not equal to
         │                                               `'a -> 'a`
@@ -2039,8 +2041,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:47:34
-     47 │        let xignore = poly4 [true] [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:49:34
+     49 │        let xignore = poly4 [true] [(fun x -> x + 1)];;
         │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                        is not equal to
         │                                                      `'a -> 'a`
@@ -2067,8 +2069,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:53:34
-     53 │        let xignore = poly5 [true] [(fun x -> x + 1)];;
+        ┌─ expect_test.ml:55:34
+     55 │        let xignore = poly5 [true] [(fun x -> x + 1)];;
         │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                        is not equal to
         │                                                      `'a -> 'a`
@@ -2098,8 +2100,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:62:34
-     62 │        let xignore = poly6 [true] [(fun x -> x + 1)] [8];;
+        ┌─ expect_test.ml:64:34
+     64 │        let xignore = poly6 [true] [(fun x -> x + 1)] [8];;
         │                                   ^^^^^^^^^^^^^^^^^^ `int -> int`
         │                                                        is not equal to
         │                                                      `'a -> 'a`
@@ -2120,8 +2122,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:67:33
-     67 │        let xignore = needs_magic [(fun x -> x)];;
+        ┌─ expect_test.ml:69:33
+     69 │        let xignore = needs_magic [(fun x -> x)];;
         │                                  ^^^^^^^^^^^^^^ `'a -> 'a`
         │                                                   is not equal to
         │                                                 `'b -> 'c`
@@ -2247,8 +2249,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:24:28
-     24 │        let xignore = poly1 (fun x -> x + 1);;
+        ┌─ expect_test.ml:26:28
+     26 │        let xignore = poly1 (fun x -> x + 1);;
         │                             ^^^^^^^^^^^^^^ `'a -> int`
         │                                              is not equal to
         │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2284,8 +2286,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E012]: generic type variable escapes its scope
-        ┌─ expect_test.ml:26:36
-     26 │        let escape = fun f -> poly1 (fun x -> f x; x);;
+        ┌─ expect_test.ml:28:36
+     28 │        let escape = fun f -> poly1 (fun x -> f x; x);;
         │                                     ^^^^^^^^^^^^^^^
     |}];
   do_test
@@ -2308,8 +2310,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:30:28
-     30 │        let xignore = poly2 (fun x -> x + 1);;
+        ┌─ expect_test.ml:32:28
+     32 │        let xignore = poly2 (fun x -> x + 1);;
         │                             ^^^^^^^^^^^^^^ `'a -> int`
         │                                              is not equal to
         │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2336,8 +2338,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:36:28
-     36 │        let xignore = poly3 (fun x -> x + 1) 8;;
+        ┌─ expect_test.ml:38:28
+     38 │        let xignore = poly3 (fun x -> x + 1) 8;;
         │                             ^^^^^^^^^^^^^^ `'a -> int`
         │                                              is not equal to
         │                                            `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2362,8 +2364,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:40:33
-     40 │        let xignore = poly4 true (fun x -> x + 1);;
+        ┌─ expect_test.ml:42:33
+     42 │        let xignore = poly4 true (fun x -> x + 1);;
         │                                  ^^^^^^^^^^^^^^ `'a -> int`
         │                                                   is not equal to
         │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2388,8 +2390,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:44:33
-     44 │        let xignore = poly5 true (fun x -> x + 1);;
+        ┌─ expect_test.ml:46:33
+     46 │        let xignore = poly5 true (fun x -> x + 1);;
         │                                  ^^^^^^^^^^^^^^ `'a -> int`
         │                                                   is not equal to
         │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2416,8 +2418,8 @@ let%expect_test "" =
   [%expect
     {|
     error[E011]: mismatched type
-        ┌─ expect_test.ml:50:33
-     50 │        let xignore = poly6 true (fun x -> x + 1) 8;;
+        ┌─ expect_test.ml:52:33
+     52 │        let xignore = poly6 true (fun x -> x + 1) 8;;
         │                                  ^^^^^^^^^^^^^^ `'a -> int`
         │                                                   is not equal to
         │                                                 `'b @(ν'a. [∀. 'a]) -> 'b`
@@ -2458,42 +2460,44 @@ let%expect_test "" =
      17 │ │        | Cons of 'a * 'a list
      18 │ │      ;;
      19 │ │
-     20 │ │        let poly1 = fun (forall id : 'a. 'a -> 'a) ->
-     21 │ │          (id 1, id true)
-     22 │ │        ;;
-     23 │ │
-     24 │ │        let id = fun x -> x;;
+     20 │ │      external map_list : 'a 'b. ('a -> 'b) -> 'a list -> 'b list;;
+     21 │ │
+     22 │ │        let poly1 = fun (forall id : 'a. 'a -> 'a) ->
+     23 │ │          (id 1, id true)
+     24 │ │        ;;
      25 │ │
-     26 │ │        let poly2 = fun (forall id : 'a. 'a -> 'a) ->
-     27 │ │          ((id 1, id true) : int * bool)
-     28 │ │        ;;
-     29 │ │
-     30 │ │        let poly3 =
-     31 │ │          forall (type 'b) ->
-     32 │ │            fun (forall id : 'a. 'a -> 'a) (x : 'b) ->
-     33 │ │              ((id x, id (Some x)) : 'b * 'b option)
-     34 │ │        ;;
-     35 │ │
-     36 │ │        let poly4 = fix (fun poly4 p (forall id : 'a. 'a -> 'a) ->
-     37 │ │          if p then poly4 false id else (id 4, id true))
-     38 │ │        ;;
-     39 │ │
-     40 │ │        let poly5 = fix (fun poly5 (p : bool) (forall id : 'a. 'a -> 'a) ->
-     41 │ │          ((if p then poly5 false id else (id 5, id true)) : int * bool))
-     42 │ │        ;;
-     43 │ │
-     44 │ │        let poly6 = forall (type 'b) ->
-     45 │ │          fix (fun poly6 ->
-     46 │ │            fun (p : bool) (forall id : 'a. 'a -> 'a) (x : 'b) ->
-     47 │ │              ((if p then poly6 false id x else (id x, id (Some x))) : 'b * 'b option))
-     48 │ │        ;;
-     49 │ │
-     50 │ │        let needs_magic = fun (forall magic : 'a 'b. 'a -> 'b) ->
-     51 │ │          (magic 5 : bool)
-     52 │ │        ;;
-     53 │ │
-     54 │ │        let xignore = needs_magic (fun x -> x);;
+     26 │ │        let id = fun x -> x;;
+     27 │ │
+     28 │ │        let poly2 = fun (forall id : 'a. 'a -> 'a) ->
+     29 │ │          ((id 1, id true) : int * bool)
+     30 │ │        ;;
+     31 │ │
+     32 │ │        let poly3 =
+     33 │ │          forall (type 'b) ->
+     34 │ │            fun (forall id : 'a. 'a -> 'a) (x : 'b) ->
+     35 │ │              ((id x, id (Some x)) : 'b * 'b option)
+     36 │ │        ;;
+     37 │ │
+     38 │ │        let poly4 = fix (fun poly4 p (forall id : 'a. 'a -> 'a) ->
+     39 │ │          if p then poly4 false id else (id 4, id true))
+     40 │ │        ;;
+     41 │ │
+     42 │ │        let poly5 = fix (fun poly5 (p : bool) (forall id : 'a. 'a -> 'a) ->
+     43 │ │          ((if p then poly5 false id else (id 5, id true)) : int * bool))
+     44 │ │        ;;
+     45 │ │
+     46 │ │        let poly6 = forall (type 'b) ->
+     47 │ │          fix (fun poly6 ->
+     48 │ │            fun (p : bool) (forall id : 'a. 'a -> 'a) (x : 'b) ->
+     49 │ │              ((if p then poly6 false id x else (id x, id (Some x))) : 'b * 'b option))
+     50 │ │        ;;
+     51 │ │
+     52 │ │        let needs_magic = fun (forall magic : 'a 'b. 'a -> 'b) ->
+     53 │ │          (magic 5 : bool)
+     54 │ │        ;;
      55 │ │
+     56 │ │        let xignore = needs_magic (fun x -> x);;
+     57 │ │
         │ ╰─────^ `'a`
                  is not equal to
                `'b`
@@ -3213,6 +3217,438 @@ let%expect_test "" =
         ┌─ expect_test.ml:2:26
       2 │        let _ = fun f -> f f;;
         │                           ^
+        = hint: add a type annotation
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    {|
+      let x = 1;;
+      let y = true;;
+      let z = ();; 
+
+
+      let f = 
+        let q?a = x in
+        let r?a = y in
+        let s?a = z in
+        (a : int)
+      ;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let include_array =
+  {|
+    type 'a array;; 
+
+    external map_array : 'a 'b. ('a -> 'b) -> 'a array -> 'b array;;
+  |}
+;;
+
+let include_float =
+  {|
+    type float;; 
+
+    external add_float : float -> float -> float;;
+    external sub_float : float -> float -> float;;
+    external div_float : float -> float -> float;;
+    external mul_float : float -> float -> float;;
+
+    external compare_float : float -> float -> int;;
+
+    external float_of_int : int -> float;;
+
+    let zero_float = float_of_int 0;;
+    let neg_float = fun n -> sub_float zero_float n;;
+  |}
+;;
+
+let include_string =
+  {|
+    type string;;
+
+    external empty_string : string;;
+    external concat_string : string -> string -> string;;
+    external length_string : string -> int;;
+  |}
+;;
+
+let%expect_test "" =
+  let test =
+    Incremental_test.create
+      ~initial:
+        (include_float
+         ^ include_array
+         ^ include_list
+         ^ include_string
+         ^ {|
+             let int?add = fun x y -> x + y;; 
+             let float?add = add_float;;
+
+             let int?mul = fun x y -> x * y;;
+             let float?mul = mul_float;;
+
+             let int?compare = fun x y -> 
+               if x < y then -1
+               else if x > y then 1
+               else 0
+             ;; 
+             let float?compare = compare_float;;
+
+             let int?zero = 0;; 
+             let float?zero = zero_float;;
+
+             let int?one = 1;; 
+             let float?one = float_of_int 1;;
+
+             let int?two = 2;;
+             let float?two = float_of_int 2;;  
+
+             let int?three = 3;;
+             let float?three = float_of_int 3;;
+
+             let int?four = 4;;
+             let float?four = float_of_int 4;;
+
+             let int?fourty_two = 42;;
+             let float?fourty_two = float_of_int 42;;
+           |}
+        )
+      type_check_and_print
+  in
+  let do_test = Incremental_test.run test in
+  do_test
+    {|
+      let ex1 = fun (x : int) (y : int) -> add x y;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex1_bad = fun (x : int) (y : float) -> add x y;;
+    |};
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:64:56
+     64 │        let ex1_bad = fun (x : int) (y : float) -> add x y;;
+        │                                                         ^ `float`
+        │                                                             is not equal to
+        │                                                           `int`
+    |}];
+  do_test
+    {|
+      let ex2 = fun (x : float) (y : float) -> add x y;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex3 = (zero : int);; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex4 = fun (x : int) -> add x zero;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex5 = fun (x : float) -> add x zero;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex6 = (add (add three four) (add one (add zero two)) : float);; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ambig = add;;
+    |};
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:64:19
+     64 │        let ambig = add;;
+        │                    ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:64:19
+     64 │        let ambig = add;;
+        │                    ^^^
+        = hint: add a type annotation
+    |}];
+  do_test
+    {|
+      let ex7 = 
+        (add (add three four) (add one (add zero two)) : int)
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let ex8 = fun (x : float) ->
+        if (compare x zero < 0) then 
+          add zero one 
+        else 
+          mul two x 
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet1 = fun (f : int -> int) (g : int -> int) (x : int) -> 
+        (add (f (add x fourty_two)) (g (add (mul two x) fourty_two)) : int)
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet1' = fun (f : float -> float) (g : float -> float) x -> 
+        add (f (add x fourty_two)) (g (add (mul two x) fourty_two))
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet1'' = fun (f : float -> float) g x -> 
+        add (f (add x fourty_two)) (g (add (mul two x) fourty_two))
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet2 = fun (f : int -> int) (g : int -> int) (x : int) -> 
+        let op = fun n -> add n fourty_two in 
+        (add (f (op x)) (g (op (mul two x))) : int)
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let exlet2' = fun (f : float -> float) (g : float -> float) x -> 
+        let op = fun (n : float) -> add n fourty_two in 
+        add (f (op x)) (g (op (mul two x)))
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let list?map = map_list;;
+      let array?map = map_array;;
+
+      external d : float array;; 
+
+      let ex12 = 
+        map (fun x -> add (mul two x) one) d
+      ;; 
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let example_success =
+        let x = (zero : float) in 
+        let y = add one x in 
+        let z = (two : float) in 
+        let t = (add (add three y) (add four z) : float) in 
+        add (add four z) one 
+      ;; 
+    |};
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_string
+    ^ {|
+      let add = fun x y -> x + y;; 
+      let concat = (concat_string : string -> string -> string);; 
+
+      let g0 = fun x -> 
+        let int?f = add in 
+        let string?f = concat in
+        f 1 x 
+      ;;
+
+      let g1 = fun (x : int) -> 
+        let int?f = add in 
+        let string?f = concat in
+        let fx = f x in 
+        let int?a = 1 in 
+        let string?a = empty_string in 
+        let z = (f : int -> int -> int) a in 
+        (fx, z)
+      ;; 
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_float
+    ^ {|
+      let int?zero = 0;; 
+      let float?zero = zero_float;; 
+      
+      type not_int_or_float;;
+      let foo = 
+        (zero : not_int_or_float)
+      ;; 
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:21:10
+     21 │          (zero : not_int_or_float)
+        │           ^^^^ `float`
+        │                  is not equal to
+        │                `not_int_or_float`
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_float
+    ^ include_string
+    ^ {|
+      let int?x = 1;;
+      let string?x = empty_string;;
+
+      let float?y = float_of_int 1;;
+      let int?y = 1;;
+
+      let int?add = fun x y -> x + y;;
+      let float?add = add_float;;
+
+      let z = add x y;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:21
+     31 │        let z = add x y;;
+        │                      ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:21
+     31 │        let z = add x y;;
+        │                      ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:19
+     31 │        let z = add x y;;
+        │                    ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:19
+     31 │        let z = add x y;;
+        │                    ^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:31:15
+     31 │        let z = add x y;;
+        │                ^^^
+        = hint: add a type annotation
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    {|
+      type t;; 
+      type s;;
+      type r;;
+
+      external foo : t -> s -> r;;
+      external bar : r -> r -> r;;
+    
+      let foo?foo_bar = foo;;
+      let bar?foo_bar = bar;;
+
+      let z = fun x -> foo_bar x x;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
+        = hint: add a type annotation
+
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:12:24
+     12 │        let z = fun x -> foo_bar x x;;
+        │                         ^^^^^^^
         = hint: add a type annotation
     |}]
 ;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -3549,6 +3549,8 @@ let%expect_test "" =
 ;;
 
 let%expect_test "" =
+  (* This demonstrates that we cannot use multiple 
+     match constraints together to solve the overloading. *)
   let str =
     {|
       type t;; 
@@ -3572,5 +3574,264 @@ let%expect_test "" =
      12 │        let z = fun x -> foo_bar x x;;
         │                         ^^^^^^^
         = hint: add a type annotation
+    |}]
+;;
+
+let%expect_test "" =
+  let str =
+    {|
+      let f = fun? x -> x + 1;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    {|
+      let value = 42;;
+      let implicit value;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    {|
+      let f = fun? x -> x;;
+      let value = 10;;
+      let implicit value;;
+      let result = f;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_string
+    ^ {|
+      external show_int : int -> string;;
+      let implicit show_int;;
+      let show = fun? showx -> fun x -> (showx x : string);;
+      let _ = show 42;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  let str =
+    include_option
+    ^ include_list
+    ^ {|
+      let some = fun x -> Some x;;
+      let implicit some;;
+
+      let singleton = fun x -> Cons (x, Nil);;
+      let implicit singleton;;
+
+      let wrap = fun? wrapper -> fun x -> wrapper x;;
+      let result = exists (type 'a) -> (wrap 42 : 'a option);;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let include_show =
+  {|
+    type 'a show = { show : 'a -> string };;
+    let show = fun ?showx -> fun x -> showx.show x;;
+  |}
+;;
+
+let include_show_int =
+  {|
+    external show_int : int -> string;;
+    let show_int = { show = show_int };;
+    let implicit show_int;;
+  |}
+;;
+
+let include_show_float =
+  {|
+    external show_float : float -> string;;
+    let show_float = { show = show_float };;
+    let implicit show_float;;
+  |}
+;;
+
+let%expect_test "" =
+  let str =
+    include_fix
+    ^ include_list
+    ^ include_float
+    ^ include_string
+    ^ include_show
+    ^ include_show_int
+    ^ include_show_float
+    ^ {|
+      external nil_string : string;;
+      external cons_string : string -> string -> string;;
+
+      let show_list = fun? showx ->
+        fix (fun show_list xs ->
+          match xs with (
+          | Nil -> nil_string
+          | Cons (x, xs) -> cons_string (showx.show x) (show_list xs)))
+      ;;
+      let show_list = { show = show_list };;
+      let implicit show_list;;
+
+      let _ = show (Cons (1, Cons (2, Nil)));;
+    |}
+  in
+  type_check_and_print str;
+  [%expect {| Well typed :) |}]
+;;
+
+let include_monoid =
+  {|
+    type 'a monoid = 
+      { unit : 'a
+      ; plus : 'a -> 'a -> 'a
+      }
+    ;;
+  |}
+;;
+
+let include_monoid_int =
+  {|
+    let monoid_int = 
+      { unit = 0
+      ; plus = fun x y -> x + y
+      }
+    ;;
+    let implicit monoid_int;;
+  |}
+;;
+
+let include_monoid_float =
+  {|
+    let monoid_float = 
+      { unit = zero_float
+      ; plus = add_float
+      }
+    ;;
+    let implicit monoid_float;;
+  |}
+;;
+
+let include_monoid_string =
+  {|
+    let monoid_string = 
+      { unit = empty_string
+      ; plus = concat_string
+      }
+    ;;
+    let implicit monoid_string;;
+  |}
+;;
+
+let%expect_test "" =
+  let test =
+    Incremental_test.create
+      ~initial:
+        (include_fix
+         ^ include_list
+         ^ include_float
+         ^ include_string
+         ^ include_monoid
+         ^ include_monoid_int
+         ^ include_monoid_float
+         ^ include_monoid_string)
+      type_check_and_print
+  in
+  let do_test = Incremental_test.run test in
+  do_test
+    ~add:true
+    {|
+      let sum = fun? m -> fix (fun sum xs -> 
+        match xs with
+        ( Nil -> m.unit
+        | Cons (x, xs) -> m.plus x (sum xs)))
+      ;;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let _ = sum (Cons (1, Cons (2, Cons (3, Nil))));;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let _ = sum (Cons (float_of_int 1, Cons (float_of_int 42, Nil)));;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let _ = sum (Cons (empty_string, Nil));;
+    |};
+  [%expect {| Well typed :) |}];
+  do_test
+    {|
+      let _ = sum Nil;;
+    |};
+  [%expect
+    {|
+    error[E017]: ambiguous overloading
+        ┌─ expect_test.ml:62:15
+     62 │        let _ = sum Nil;;
+        │                ^^^
+        = hint: add a type annotation
+    |}];
+  do_test
+    {|
+      let monoid_pair = fun? mfst msnd -> 
+        { unit = (mfst.unit, msnd.unit)
+        ; plus = (fun (x11, x12) (x21, x22) -> (mfst.plus x11 x21, msnd.plus x21 x22))
+        }
+      ;;
+
+      let implicit monoid_pair;;
+      let _ = sum (Cons ((1, 42), Cons ((2, 1337), Cons ((3, 88), Nil))));;
+    |};
+  [%expect {| Well typed :) |}]
+;;
+
+let%expect_test "" =
+  (* The error message is poor here, but this fails because 'a is 
+     rigid and the expected argument type of `trans` is some shape 
+     variable with a match on. Unification fails. *)
+  let str =
+    {|
+      type 'a trans = { trans : 'a -> 'a };;
+
+      let trans_a = { trans = fun x -> x };;
+      let implicit trans_a;;
+
+      let trans_int = { trans = fun x -> x + 1 };; 
+      let implicit trans_int;;
+
+      let trans = fun ?transx -> fun x -> transx.trans x;;
+
+      let bad = forall (type 'a) -> fun (x : 'a) -> trans x;;
+    |}
+  in
+  type_check_and_print str;
+  [%expect
+    {|
+    error[E011]: mismatched type
+        ┌─ expect_test.ml:12:59
+     12 │        let bad = forall (type 'a) -> fun (x : 'a) -> trans x;;
+        │                                                            ^ `'a`
+        │                                                                is not equal to
+        │                                                              `'b`
     |}]
 ;;

--- a/lib/main/test/test_main.ml
+++ b/lib/main/test/test_main.ml
@@ -13,6 +13,7 @@ let type_check_and_print
       ?(with_stdlib = true)
       ?(with_poly_params = false)
       ?(defaulting = Options.Defaulting.default)
+      ?(termination_check = Options.Termination_check.default)
       ?(log_level = `Info)
       str
   =
@@ -25,6 +26,7 @@ let type_check_and_print
     ~with_stdlib
     ~with_poly_params
     ~defaulting
+    ~termination_check
     (Lexing.from_string ~with_positions:true str)
 ;;
 

--- a/lib/options/omniml_options.ml
+++ b/lib/options/omniml_options.ml
@@ -23,5 +23,34 @@ module Defaulting = struct
   include T
 
   let default = Disabled
-  let arg_type = Command.Arg_type.enumerated_sexpable (module T)
+  let arg_type = Command.Arg_type.enumerated_sexpable ~case_sensitive:false (module T)
+end
+
+module Termination_check = struct
+  module T = struct
+    type t =
+      | Disabled
+      | Threshold of int
+      | Decreasing_instantiations
+    [@@deriving sexp]
+  end
+
+  include T
+
+  let default = Threshold 256
+
+  let arg_type =
+    Command.Arg_type.create (fun arg_str ->
+      match String.lowercase arg_str with
+      | "disabled" -> Disabled
+      | "decreasing-instantiations" -> Decreasing_instantiations
+      | s when String.is_prefix s ~prefix:"threshold:" ->
+        let n = String.drop_prefix s 10 |> Int.of_string in
+        Threshold n
+      | _ ->
+        Error.(
+          raise
+            (of_string
+               "expected one of: disabled, threshold:<int>, decreasing-instantiations")))
+  ;;
 end

--- a/lib/options/omniml_options.mli
+++ b/lib/options/omniml_options.mli
@@ -20,3 +20,13 @@ module Defaulting : sig
 
   include S_with_default with type t := t
 end
+
+module Termination_check : sig
+  type t =
+    | Disabled
+    | Threshold of int
+    | Decreasing_instantiations
+  [@@deriving sexp]
+
+  include S_with_default with type t := t
+end

--- a/lib/parser/lexer.mll
+++ b/lib/parser/lexer.mll
@@ -75,6 +75,8 @@ rule read  =
       { UNDERSCORE }
   | "|"
       { BAR }
+  | "?"
+      { QUESTION_MARK }
 
   (* comments *)
   | "(*"

--- a/lib/parser/lexer.mll
+++ b/lib/parser/lexer.mll
@@ -22,6 +22,7 @@ let keywords =
   ; "as", AS 
   ; "of", OF 
   ; "external", EXTERNAL
+  ; "implicit", IMPLICIT
   ]
 ;;
 

--- a/lib/parser/omniml_parser.ml
+++ b/lib/parser/omniml_parser.ml
@@ -35,6 +35,7 @@ module Token = struct
     | LEFT_BRACKET -> Fmt.pf ppf "Left_bracket"
     | LEFT_BRACE -> Fmt.pf ppf "Left_brace"
     | IN -> Fmt.pf ppf "In"
+    | IMPLICIT -> Fmt.pf ppf "Implicit"
     | IF -> Fmt.pf ppf "If"
     | IDENT ident -> Fmt.pf ppf "Ident(%s)" ident
     | GREATER_EQUAL -> Fmt.pf ppf "Greater_equal"

--- a/lib/parser/omniml_parser.ml
+++ b/lib/parser/omniml_parser.ml
@@ -22,6 +22,7 @@ module Token = struct
     | RIGHT_BRACE -> Fmt.pf ppf "Right_brace"
     | RIGHT_ARROW -> Fmt.pf ppf "Right_arrow"
     | QUOTE -> Fmt.pf ppf "Quote"
+    | QUESTION_MARK -> Fmt.pf ppf "Question_mark"
     | PLUS -> Fmt.pf ppf "Plus"
     | OF -> Fmt.pf ppf "Of"
     | MINUS -> Fmt.pf ppf "Minus"

--- a/lib/parser/parser.mly
+++ b/lib/parser/parser.mly
@@ -308,6 +308,12 @@ expression:
     ; "in"
     ; exp = seq_expression
       { Expression.let_ ~range:(range_of_lex $loc) value_binding ~in_:exp }
+  | "let"
+    ; "implicit"
+    ; var_name = var_name
+    ; "in"
+    ; exp = seq_expression
+      { Expression.let_implicit ~range:(range_of_lex $loc) var_name ~in_:exp }
 
 app_expression:
     exp = atom_expression
@@ -322,8 +328,8 @@ app_expression:
 value_binding:
   pat = pattern 
   ; "="
-  ; exp = seq_expression
-    { value_binding ~range:(range_of_lex $loc) pat exp }
+  ; term = term
+    { value_binding ~range:(range_of_lex $loc) pat term }
 
 cases:
   "("
@@ -441,6 +447,16 @@ function_param:
           scheme
       }
 
+term:
+    exp = seq_expression
+      { Term.exp ~range:(range_of_lex $loc) exp }
+  | "fun"
+    ; "?"
+    ; pats = nonempty_list(atom_pattern)
+    ; "->"
+    ; exp = seq_expression
+      { Term.implicit_fun ~range:(range_of_lex $loc) pats exp }
+
 pattern:
     pat = construct_pattern
       { pat }
@@ -553,6 +569,10 @@ structure_item:
     "let"
     ; value_binding = value_binding
       { Structure.value ~range:(range_of_lex $loc) value_binding }
+  | "let"
+    ; "implicit"
+    ; var_name = var_name
+      { Structure.implicit ~range:(range_of_lex $loc) var_name }
   | "external"
     ; value_desc = value_description
       { Structure.primitive ~range:(range_of_lex $loc) value_desc }

--- a/lib/parser/parser.mly
+++ b/lib/parser/parser.mly
@@ -398,6 +398,8 @@ atom_expression:
     ; exp = seq_expression
     ; ")"
       { exp }
+  | "?"
+      { Expression.implicit ~range:(range_of_lex $loc) }
 
 %inline unary_op:
   "-"

--- a/lib/parser/parser.mly
+++ b/lib/parser/parser.mly
@@ -232,6 +232,16 @@ core_scheme:
   id = "<ident>"
     { label_name ~range:(range_of_lex $loc) id }
 
+%inline over_name:
+  id = "<ident>"
+    { over_name ~range:(range_of_lex $loc) id }
+
+%inline over_path:
+  over_name = over_name
+  ; "?"
+  ; var_name = var_name
+    { over_path ~range:(range_of_lex $loc) over_name var_name }
+
 constant:
     int = "<int>"
       { Const_int int }
@@ -338,6 +348,8 @@ atom_expression:
       { Expression.const ~range:(range_of_lex $loc) const }
   | var_name = var_name
       { Expression.var ~range:(range_of_lex $loc) var_name }
+  | over_path = over_path
+      { Expression.over ~range:(range_of_lex $loc) over_path }
   | constr_name = constr_name
       { Expression.constr ~range:(range_of_lex $loc) constr_name None }
   | "("
@@ -451,6 +463,8 @@ atom_pattern:
       { Pattern.any ~range:(range_of_lex $loc) }
   | var_name = var_name
       { Pattern.var ~range:(range_of_lex $loc) var_name }
+  | over_path = over_path
+      { Pattern.over ~range:(range_of_lex $loc) over_path }
   | constr_name = constr_name
       { Pattern.constr ~range:(range_of_lex $loc) constr_name None }
   | "("

--- a/lib/parser/test/test_lexer.ml
+++ b/lib/parser/test/test_lexer.ml
@@ -80,6 +80,7 @@ let%expect_test "keywords" =
   ; ">="
   ; "<="
   ; "<>"
+  ; "?"
   ]
   |> List.iter ~f:(fun keyword ->
     Fmt.pr "Keyword: %s @.Output: " keyword;
@@ -162,6 +163,8 @@ let%expect_test "keywords" =
     Output: Less_equal
     Keyword: <>
     Output: Less_greater
+    Keyword: ?
+    Output: Question_mark
     |}]
 ;;
 

--- a/lib/parser/test/test_parser.ml
+++ b/lib/parser/test/test_parser.ml
@@ -4910,3 +4910,542 @@ let%expect_test "polyparam - function" =
         (Reader ((id 0) (name (expect_test.ml)) (length 59) (unsafe_get <fun>)))))))
     |}]
 ;;
+
+let%expect_test "structure implicit function" =
+  let str =
+    {|
+      let foo = fun ?bar x -> bar x;;
+    |}
+  in
+  parse_and_print_structure str;
+  [%expect {|
+    (((it
+       (Str_value
+        ((it
+          ((value_binding_pat
+            ((it
+              (Pat_var
+               ((it foo)
+                (range
+                 ((start 11) (stop 14)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 43)
+                     (unsafe_get <fun>)))))))))
+             (range
+              ((start 11) (stop 14)
+               (source
+                (Reader
+                 ((id 0) (name (expect_test.ml)) (length 43) (unsafe_get <fun>))))))))
+           (value_binding_term
+            ((it
+              (Term_implicit_fun
+               (((it
+                  (Pat_var
+                   ((it bar)
+                    (range
+                     ((start 22) (stop 25)
+                      (source
+                       (Reader
+                        ((id 0) (name (expect_test.ml)) (length 43)
+                         (unsafe_get <fun>)))))))))
+                 (range
+                  ((start 22) (stop 25)
+                   (source
+                    (Reader
+                     ((id 0) (name (expect_test.ml)) (length 43)
+                      (unsafe_get <fun>)))))))
+                ((it
+                  (Pat_var
+                   ((it x)
+                    (range
+                     ((start 26) (stop 27)
+                      (source
+                       (Reader
+                        ((id 0) (name (expect_test.ml)) (length 43)
+                         (unsafe_get <fun>)))))))))
+                 (range
+                  ((start 26) (stop 27)
+                   (source
+                    (Reader
+                     ((id 0) (name (expect_test.ml)) (length 43)
+                      (unsafe_get <fun>))))))))
+               ((it
+                 (Exp_app
+                  ((it
+                    (Exp_var
+                     ((it bar)
+                      (range
+                       ((start 31) (stop 34)
+                        (source
+                         (Reader
+                          ((id 0) (name (expect_test.ml)) (length 43)
+                           (unsafe_get <fun>)))))))))
+                   (range
+                    ((start 31) (stop 34)
+                     (source
+                      (Reader
+                       ((id 0) (name (expect_test.ml)) (length 43)
+                        (unsafe_get <fun>)))))))
+                  ((it
+                    (Exp_var
+                     ((it x)
+                      (range
+                       ((start 35) (stop 36)
+                        (source
+                         (Reader
+                          ((id 0) (name (expect_test.ml)) (length 43)
+                           (unsafe_get <fun>)))))))))
+                   (range
+                    ((start 35) (stop 36)
+                     (source
+                      (Reader
+                       ((id 0) (name (expect_test.ml)) (length 43)
+                        (unsafe_get <fun>)))))))))
+                (range
+                 ((start 31) (stop 36)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 43)
+                     (unsafe_get <fun>)))))))))
+             (range
+              ((start 17) (stop 36)
+               (source
+                (Reader
+                 ((id 0) (name (expect_test.ml)) (length 43) (unsafe_get <fun>))))))))))
+         (range
+          ((start 11) (stop 36)
+           (source
+            (Reader
+             ((id 0) (name (expect_test.ml)) (length 43) (unsafe_get <fun>)))))))))
+      (range
+       ((start 7) (stop 36)
+        (source
+         (Reader ((id 0) (name (expect_test.ml)) (length 43) (unsafe_get <fun>))))))))
+    |}]
+;;
+
+let%expect_test "structure implicit let" =
+  let str =
+    {|
+      let x = 1;;
+
+      let implicit x;;
+    |}
+  in
+  parse_and_print_structure str;
+  [%expect {|
+    (((it
+       (Str_value
+        ((it
+          ((value_binding_pat
+            ((it
+              (Pat_var
+               ((it x)
+                (range
+                 ((start 11) (stop 12)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 47)
+                     (unsafe_get <fun>)))))))))
+             (range
+              ((start 11) (stop 12)
+               (source
+                (Reader
+                 ((id 0) (name (expect_test.ml)) (length 47) (unsafe_get <fun>))))))))
+           (value_binding_term
+            ((it
+              (Term_exp
+               ((it (Exp_const (Const_int 1)))
+                (range
+                 ((start 15) (stop 16)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 47)
+                     (unsafe_get <fun>)))))))))
+             (range
+              ((start 15) (stop 16)
+               (source
+                (Reader
+                 ((id 0) (name (expect_test.ml)) (length 47) (unsafe_get <fun>))))))))))
+         (range
+          ((start 11) (stop 16)
+           (source
+            (Reader
+             ((id 0) (name (expect_test.ml)) (length 47) (unsafe_get <fun>)))))))))
+      (range
+       ((start 7) (stop 16)
+        (source
+         (Reader ((id 0) (name (expect_test.ml)) (length 47) (unsafe_get <fun>)))))))
+     ((it
+       (Str_implicit
+        ((it x)
+         (range
+          ((start 39) (stop 40)
+           (source
+            (Reader
+             ((id 0) (name (expect_test.ml)) (length 47) (unsafe_get <fun>)))))))))
+      (range
+       ((start 26) (stop 40)
+        (source
+         (Reader ((id 0) (name (expect_test.ml)) (length 47) (unsafe_get <fun>))))))))
+    |}]
+;;
+
+let%expect_test "expression implicit function" =
+  let exp =
+    {|
+      let add = fun ?x y -> x + y in
+      add 1
+    |}
+  in
+  parse_and_print_expression exp;
+  [%expect {|
+    ((it
+      (Exp_let
+       ((it
+         ((value_binding_pat
+           ((it
+             (Pat_var
+              ((it add)
+               (range
+                ((start 11) (stop 14)
+                 (source
+                  (Reader
+                   ((id 0) (name (expect_test.ml)) (length 54)
+                    (unsafe_get <fun>)))))))))
+            (range
+             ((start 11) (stop 14)
+              (source
+               (Reader
+                ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>))))))))
+          (value_binding_term
+           ((it
+             (Term_implicit_fun
+              (((it
+                 (Pat_var
+                  ((it x)
+                   (range
+                    ((start 22) (stop 23)
+                     (source
+                      (Reader
+                       ((id 0) (name (expect_test.ml)) (length 54)
+                        (unsafe_get <fun>)))))))))
+                (range
+                 ((start 22) (stop 23)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 54)
+                     (unsafe_get <fun>)))))))
+               ((it
+                 (Pat_var
+                  ((it y)
+                   (range
+                    ((start 24) (stop 25)
+                     (source
+                      (Reader
+                       ((id 0) (name (expect_test.ml)) (length 54)
+                        (unsafe_get <fun>)))))))))
+                (range
+                 ((start 24) (stop 25)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 54)
+                     (unsafe_get <fun>))))))))
+              ((it
+                (Exp_app
+                 ((it
+                   (Exp_app
+                    ((it
+                      (Exp_var
+                       ((it "( + )")
+                        (range
+                         ((start 31) (stop 32)
+                          (source
+                           (Reader
+                            ((id 0) (name (expect_test.ml)) (length 54)
+                             (unsafe_get <fun>)))))))))
+                     (range
+                      ((start 29) (stop 34)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 54)
+                          (unsafe_get <fun>)))))))
+                    ((it
+                      (Exp_var
+                       ((it x)
+                        (range
+                         ((start 29) (stop 30)
+                          (source
+                           (Reader
+                            ((id 0) (name (expect_test.ml)) (length 54)
+                             (unsafe_get <fun>)))))))))
+                     (range
+                      ((start 29) (stop 30)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 54)
+                          (unsafe_get <fun>)))))))))
+                  (range
+                   ((start 29) (stop 34)
+                    (source
+                     (Reader
+                      ((id 0) (name (expect_test.ml)) (length 54)
+                       (unsafe_get <fun>)))))))
+                 ((it
+                   (Exp_var
+                    ((it y)
+                     (range
+                      ((start 33) (stop 34)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 54)
+                          (unsafe_get <fun>)))))))))
+                  (range
+                   ((start 33) (stop 34)
+                    (source
+                     (Reader
+                      ((id 0) (name (expect_test.ml)) (length 54)
+                       (unsafe_get <fun>)))))))))
+               (range
+                ((start 29) (stop 34)
+                 (source
+                  (Reader
+                   ((id 0) (name (expect_test.ml)) (length 54)
+                    (unsafe_get <fun>)))))))))
+            (range
+             ((start 17) (stop 34)
+              (source
+               (Reader
+                ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>))))))))))
+        (range
+         ((start 11) (stop 34)
+          (source
+           (Reader
+            ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>)))))))
+       ((it
+         (Exp_app
+          ((it
+            (Exp_var
+             ((it add)
+              (range
+               ((start 44) (stop 47)
+                (source
+                 (Reader
+                  ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>)))))))))
+           (range
+            ((start 44) (stop 47)
+             (source
+              (Reader
+               ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>)))))))
+          ((it (Exp_const (Const_int 1)))
+           (range
+            ((start 48) (stop 49)
+             (source
+              (Reader
+               ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>)))))))))
+        (range
+         ((start 44) (stop 49)
+          (source
+           (Reader
+            ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>)))))))))
+     (range
+      ((start 7) (stop 49)
+       (source
+        (Reader ((id 0) (name (expect_test.ml)) (length 54) (unsafe_get <fun>)))))))
+    |}]
+;;
+
+let%expect_test "expression implicit hole" =
+  let exp =
+    {|
+      let add = fun ?x y -> x + y in
+      (? : int -> int)
+    |}
+  in
+  parse_and_print_expression exp;
+  [%expect {|
+    ((it
+      (Exp_let
+       ((it
+         ((value_binding_pat
+           ((it
+             (Pat_var
+              ((it add)
+               (range
+                ((start 11) (stop 14)
+                 (source
+                  (Reader
+                   ((id 0) (name (expect_test.ml)) (length 65)
+                    (unsafe_get <fun>)))))))))
+            (range
+             ((start 11) (stop 14)
+              (source
+               (Reader
+                ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>))))))))
+          (value_binding_term
+           ((it
+             (Term_implicit_fun
+              (((it
+                 (Pat_var
+                  ((it x)
+                   (range
+                    ((start 22) (stop 23)
+                     (source
+                      (Reader
+                       ((id 0) (name (expect_test.ml)) (length 65)
+                        (unsafe_get <fun>)))))))))
+                (range
+                 ((start 22) (stop 23)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 65)
+                     (unsafe_get <fun>)))))))
+               ((it
+                 (Pat_var
+                  ((it y)
+                   (range
+                    ((start 24) (stop 25)
+                     (source
+                      (Reader
+                       ((id 0) (name (expect_test.ml)) (length 65)
+                        (unsafe_get <fun>)))))))))
+                (range
+                 ((start 24) (stop 25)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 65)
+                     (unsafe_get <fun>))))))))
+              ((it
+                (Exp_app
+                 ((it
+                   (Exp_app
+                    ((it
+                      (Exp_var
+                       ((it "( + )")
+                        (range
+                         ((start 31) (stop 32)
+                          (source
+                           (Reader
+                            ((id 0) (name (expect_test.ml)) (length 65)
+                             (unsafe_get <fun>)))))))))
+                     (range
+                      ((start 29) (stop 34)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 65)
+                          (unsafe_get <fun>)))))))
+                    ((it
+                      (Exp_var
+                       ((it x)
+                        (range
+                         ((start 29) (stop 30)
+                          (source
+                           (Reader
+                            ((id 0) (name (expect_test.ml)) (length 65)
+                             (unsafe_get <fun>)))))))))
+                     (range
+                      ((start 29) (stop 30)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 65)
+                          (unsafe_get <fun>)))))))))
+                  (range
+                   ((start 29) (stop 34)
+                    (source
+                     (Reader
+                      ((id 0) (name (expect_test.ml)) (length 65)
+                       (unsafe_get <fun>)))))))
+                 ((it
+                   (Exp_var
+                    ((it y)
+                     (range
+                      ((start 33) (stop 34)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 65)
+                          (unsafe_get <fun>)))))))))
+                  (range
+                   ((start 33) (stop 34)
+                    (source
+                     (Reader
+                      ((id 0) (name (expect_test.ml)) (length 65)
+                       (unsafe_get <fun>)))))))))
+               (range
+                ((start 29) (stop 34)
+                 (source
+                  (Reader
+                   ((id 0) (name (expect_test.ml)) (length 65)
+                    (unsafe_get <fun>)))))))))
+            (range
+             ((start 17) (stop 34)
+              (source
+               (Reader
+                ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>))))))))))
+        (range
+         ((start 11) (stop 34)
+          (source
+           (Reader
+            ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>)))))))
+       ((it
+         (Exp_annot
+          ((it Exp_implicit)
+           (range
+            ((start 45) (stop 46)
+             (source
+              (Reader
+               ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>)))))))
+          ((it
+            (Type_arrow
+             ((it
+               (Param_mono_type
+                ((it
+                  (Type_constr ()
+                   ((it int)
+                    (range
+                     ((start 49) (stop 52)
+                      (source
+                       (Reader
+                        ((id 0) (name (expect_test.ml)) (length 65)
+                         (unsafe_get <fun>)))))))))
+                 (range
+                  ((start 48) (stop 52)
+                   (source
+                    (Reader
+                     ((id 0) (name (expect_test.ml)) (length 65)
+                      (unsafe_get <fun>)))))))))
+              (range
+               ((start 49) (stop 52)
+                (source
+                 (Reader
+                  ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>)))))))
+             ((it
+               (Type_constr ()
+                ((it int)
+                 (range
+                  ((start 56) (stop 59)
+                   (source
+                    (Reader
+                     ((id 0) (name (expect_test.ml)) (length 65)
+                      (unsafe_get <fun>)))))))))
+              (range
+               ((start 55) (stop 59)
+                (source
+                 (Reader
+                  ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>)))))))))
+           (range
+            ((start 49) (stop 59)
+             (source
+              (Reader
+               ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>)))))))))
+        (range
+         ((start 44) (stop 60)
+          (source
+           (Reader
+            ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>)))))))))
+     (range
+      ((start 7) (stop 60)
+       (source
+        (Reader ((id 0) (name (expect_test.ml)) (length 65) (unsafe_get <fun>)))))))
+    |}]
+;;

--- a/lib/parser/test/test_parser.ml
+++ b/lib/parser/test/test_parser.ml
@@ -4918,7 +4918,8 @@ let%expect_test "structure implicit function" =
     |}
   in
   parse_and_print_structure str;
-  [%expect {|
+  [%expect
+    {|
     (((it
        (Str_value
         ((it
@@ -5034,7 +5035,8 @@ let%expect_test "structure implicit let" =
     |}
   in
   parse_and_print_structure str;
-  [%expect {|
+  [%expect
+    {|
     (((it
        (Str_value
         ((it
@@ -5100,7 +5102,8 @@ let%expect_test "expression implicit function" =
     |}
   in
   parse_and_print_expression exp;
-  [%expect {|
+  [%expect
+    {|
     ((it
       (Exp_let
        ((it
@@ -5264,7 +5267,8 @@ let%expect_test "expression implicit hole" =
     |}
   in
   parse_and_print_expression exp;
-  [%expect {|
+  [%expect
+    {|
     ((it
       (Exp_let
        ((it

--- a/lib/parser/test/test_parser.ml
+++ b/lib/parser/test/test_parser.ml
@@ -815,31 +815,39 @@ let%expect_test "fun : map" =
               (source
                (Reader
                 ((id 0) (name (expect_test.ml)) (length 146) (unsafe_get <fun>))))))))
-          (value_binding_exp
+          (value_binding_term
            ((it
-             (Exp_app
+             (Term_exp
               ((it
-                (Exp_var
-                 ((it fix)
+                (Exp_app
+                 ((it
+                   (Exp_var
+                    ((it fix)
+                     (range
+                      ((start 12) (stop 15)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 146)
+                          (unsafe_get <fun>)))))))))
                   (range
                    ((start 12) (stop 15)
                     (source
                      (Reader
                       ((id 0) (name (expect_test.ml)) (length 146)
-                       (unsafe_get <fun>)))))))))
-               (range
-                ((start 12) (stop 15)
-                 (source
-                  (Reader
-                   ((id 0) (name (expect_test.ml)) (length 146)
-                    (unsafe_get <fun>)))))))
-              ((it
-                (Exp_fun
-                 (((it
-                    (Param_mono_val
-                     ((it
-                       (Pat_var
-                        ((it map)
+                       (unsafe_get <fun>)))))))
+                 ((it
+                   (Exp_fun
+                    (((it
+                       (Param_mono_val
+                        ((it
+                          (Pat_var
+                           ((it map)
+                            (range
+                             ((start 21) (stop 24)
+                              (source
+                               (Reader
+                                ((id 0) (name (expect_test.ml)) (length 146)
+                                 (unsafe_get <fun>)))))))))
                          (range
                           ((start 21) (stop 24)
                            (source
@@ -851,18 +859,18 @@ let%expect_test "fun : map" =
                         (source
                          (Reader
                           ((id 0) (name (expect_test.ml)) (length 146)
-                           (unsafe_get <fun>)))))))))
-                   (range
-                    ((start 21) (stop 24)
-                     (source
-                      (Reader
-                       ((id 0) (name (expect_test.ml)) (length 146)
-                        (unsafe_get <fun>)))))))
-                  ((it
-                    (Param_mono_val
+                           (unsafe_get <fun>)))))))
                      ((it
-                       (Pat_var
-                        ((it t)
+                       (Param_mono_val
+                        ((it
+                          (Pat_var
+                           ((it t)
+                            (range
+                             ((start 25) (stop 26)
+                              (source
+                               (Reader
+                                ((id 0) (name (expect_test.ml)) (length 146)
+                                 (unsafe_get <fun>)))))))))
                          (range
                           ((start 25) (stop 26)
                            (source
@@ -874,18 +882,18 @@ let%expect_test "fun : map" =
                         (source
                          (Reader
                           ((id 0) (name (expect_test.ml)) (length 146)
-                           (unsafe_get <fun>)))))))))
-                   (range
-                    ((start 25) (stop 26)
-                     (source
-                      (Reader
-                       ((id 0) (name (expect_test.ml)) (length 146)
-                        (unsafe_get <fun>)))))))
-                  ((it
-                    (Param_mono_val
+                           (unsafe_get <fun>)))))))
                      ((it
-                       (Pat_var
-                        ((it f)
+                       (Param_mono_val
+                        ((it
+                          (Pat_var
+                           ((it f)
+                            (range
+                             ((start 27) (stop 28)
+                              (source
+                               (Reader
+                                ((id 0) (name (expect_test.ml)) (length 146)
+                                 (unsafe_get <fun>)))))))))
                          (range
                           ((start 27) (stop 28)
                            (source
@@ -897,121 +905,121 @@ let%expect_test "fun : map" =
                         (source
                          (Reader
                           ((id 0) (name (expect_test.ml)) (length 146)
-                           (unsafe_get <fun>)))))))))
-                   (range
-                    ((start 27) (stop 28)
-                     (source
-                      (Reader
-                       ((id 0) (name (expect_test.ml)) (length 146)
-                        (unsafe_get <fun>))))))))
-                 ((it
-                   (Exp_match
+                           (unsafe_get <fun>))))))))
                     ((it
-                      (Exp_var
-                       ((it t)
+                      (Exp_match
+                       ((it
+                         (Exp_var
+                          ((it t)
+                           (range
+                            ((start 49) (stop 50)
+                             (source
+                              (Reader
+                               ((id 0) (name (expect_test.ml)) (length 146)
+                                (unsafe_get <fun>)))))))))
                         (range
                          ((start 49) (stop 50)
                           (source
                            (Reader
                             ((id 0) (name (expect_test.ml)) (length 146)
-                             (unsafe_get <fun>)))))))))
-                     (range
-                      ((start 49) (stop 50)
-                       (source
-                        (Reader
-                         ((id 0) (name (expect_test.ml)) (length 146)
-                          (unsafe_get <fun>)))))))
-                    (((it
-                       ((case_lhs
-                         ((it
-                           (Pat_constr
-                            ((it Nil)
+                             (unsafe_get <fun>)))))))
+                       (((it
+                          ((case_lhs
+                            ((it
+                              (Pat_constr
+                               ((it Nil)
+                                (range
+                                 ((start 71) (stop 74)
+                                  (source
+                                   (Reader
+                                    ((id 0) (name (expect_test.ml)) (length 146)
+                                     (unsafe_get <fun>)))))))
+                               ()))
                              (range
                               ((start 71) (stop 74)
                                (source
                                 (Reader
                                  ((id 0) (name (expect_test.ml)) (length 146)
-                                  (unsafe_get <fun>)))))))
-                            ()))
-                          (range
-                           ((start 71) (stop 74)
-                            (source
-                             (Reader
-                              ((id 0) (name (expect_test.ml)) (length 146)
-                               (unsafe_get <fun>))))))))
-                        (case_rhs
-                         ((it
-                           (Exp_constr
-                            ((it Nil)
+                                  (unsafe_get <fun>))))))))
+                           (case_rhs
+                            ((it
+                              (Exp_constr
+                               ((it Nil)
+                                (range
+                                 ((start 78) (stop 81)
+                                  (source
+                                   (Reader
+                                    ((id 0) (name (expect_test.ml)) (length 146)
+                                     (unsafe_get <fun>)))))))
+                               ()))
                              (range
                               ((start 78) (stop 81)
                                (source
                                 (Reader
                                  ((id 0) (name (expect_test.ml)) (length 146)
-                                  (unsafe_get <fun>)))))))
-                            ()))
-                          (range
-                           ((start 78) (stop 81)
-                            (source
-                             (Reader
-                              ((id 0) (name (expect_test.ml)) (length 146)
-                               (unsafe_get <fun>))))))))))
-                      (range
-                       ((start 71) (stop 81)
-                        (source
-                         (Reader
-                          ((id 0) (name (expect_test.ml)) (length 146)
-                           (unsafe_get <fun>)))))))
-                     ((it
-                       ((case_lhs
-                         ((it
-                           (Pat_constr
-                            ((it Cons)
+                                  (unsafe_get <fun>))))))))))
+                         (range
+                          ((start 71) (stop 81)
+                           (source
+                            (Reader
+                             ((id 0) (name (expect_test.ml)) (length 146)
+                              (unsafe_get <fun>)))))))
+                        ((it
+                          ((case_lhs
+                            ((it
+                              (Pat_constr
+                               ((it Cons)
+                                (range
+                                 ((start 96) (stop 100)
+                                  (source
+                                   (Reader
+                                    ((id 0) (name (expect_test.ml)) (length 146)
+                                     (unsafe_get <fun>)))))))
+                               ()))
                              (range
                               ((start 96) (stop 100)
                                (source
                                 (Reader
                                  ((id 0) (name (expect_test.ml)) (length 146)
-                                  (unsafe_get <fun>)))))))
-                            ()))
-                          (range
-                           ((start 96) (stop 100)
-                            (source
-                             (Reader
-                              ((id 0) (name (expect_test.ml)) (length 146)
-                               (unsafe_get <fun>))))))))
-                        (case_rhs
-                         ((it
-                           (Exp_constr
-                            ((it Cons)
-                             (range
-                              ((start 104) (stop 108)
-                               (source
-                                (Reader
-                                 ((id 0) (name (expect_test.ml)) (length 146)
-                                  (unsafe_get <fun>)))))))
-                            (((it
-                               (Exp_tuple
-                                (((it
-                                   (Exp_app
-                                    ((it
-                                      (Exp_var
-                                       ((it f)
+                                  (unsafe_get <fun>))))))))
+                           (case_rhs
+                            ((it
+                              (Exp_constr
+                               ((it Cons)
+                                (range
+                                 ((start 104) (stop 108)
+                                  (source
+                                   (Reader
+                                    ((id 0) (name (expect_test.ml)) (length 146)
+                                     (unsafe_get <fun>)))))))
+                               (((it
+                                  (Exp_tuple
+                                   (((it
+                                      (Exp_app
+                                       ((it
+                                         (Exp_var
+                                          ((it f)
+                                           (range
+                                            ((start 110) (stop 111)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 146) (unsafe_get <fun>)))))))))
                                         (range
                                          ((start 110) (stop 111)
                                           (source
                                            (Reader
                                             ((id 0) (name (expect_test.ml))
-                                             (length 146) (unsafe_get <fun>)))))))))
-                                     (range
-                                      ((start 110) (stop 111)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 146) (unsafe_get <fun>)))))))
-                                    ((it
-                                      (Exp_var
-                                       ((it x)
+                                             (length 146) (unsafe_get <fun>)))))))
+                                       ((it
+                                         (Exp_var
+                                          ((it x)
+                                           (range
+                                            ((start 112) (stop 113)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 146) (unsafe_get <fun>)))))))))
                                         (range
                                          ((start 112) (stop 113)
                                           (source
@@ -1019,39 +1027,41 @@ let%expect_test "fun : map" =
                                             ((id 0) (name (expect_test.ml))
                                              (length 146) (unsafe_get <fun>)))))))))
                                      (range
-                                      ((start 112) (stop 113)
+                                      ((start 110) (stop 113)
                                        (source
                                         (Reader
                                          ((id 0) (name (expect_test.ml))
-                                          (length 146) (unsafe_get <fun>)))))))))
-                                  (range
-                                   ((start 110) (stop 113)
-                                    (source
-                                     (Reader
-                                      ((id 0) (name (expect_test.ml))
-                                       (length 146) (unsafe_get <fun>)))))))
-                                 ((it
-                                   (Exp_app
+                                          (length 146) (unsafe_get <fun>)))))))
                                     ((it
                                       (Exp_app
                                        ((it
-                                         (Exp_var
-                                          ((it map)
+                                         (Exp_app
+                                          ((it
+                                            (Exp_var
+                                             ((it map)
+                                              (range
+                                               ((start 115) (stop 118)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 146)
+                                                   (unsafe_get <fun>)))))))))
                                            (range
                                             ((start 115) (stop 118)
                                              (source
                                               (Reader
                                                ((id 0) (name (expect_test.ml))
-                                                (length 146) (unsafe_get <fun>)))))))))
-                                        (range
-                                         ((start 115) (stop 118)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 146) (unsafe_get <fun>)))))))
-                                       ((it
-                                         (Exp_var
-                                          ((it t)
+                                                (length 146) (unsafe_get <fun>)))))))
+                                          ((it
+                                            (Exp_var
+                                             ((it t)
+                                              (range
+                                               ((start 119) (stop 120)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 146)
+                                                   (unsafe_get <fun>)))))))))
                                            (range
                                             ((start 119) (stop 120)
                                              (source
@@ -1059,20 +1069,20 @@ let%expect_test "fun : map" =
                                                ((id 0) (name (expect_test.ml))
                                                 (length 146) (unsafe_get <fun>)))))))))
                                         (range
-                                         ((start 119) (stop 120)
+                                         ((start 115) (stop 120)
                                           (source
                                            (Reader
                                             ((id 0) (name (expect_test.ml))
-                                             (length 146) (unsafe_get <fun>)))))))))
-                                     (range
-                                      ((start 115) (stop 120)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 146) (unsafe_get <fun>)))))))
-                                    ((it
-                                      (Exp_var
-                                       ((it f)
+                                             (length 146) (unsafe_get <fun>)))))))
+                                       ((it
+                                         (Exp_var
+                                          ((it f)
+                                           (range
+                                            ((start 121) (stop 122)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 146) (unsafe_get <fun>)))))))))
                                         (range
                                          ((start 121) (stop 122)
                                           (source
@@ -1080,43 +1090,43 @@ let%expect_test "fun : map" =
                                             ((id 0) (name (expect_test.ml))
                                              (length 146) (unsafe_get <fun>)))))))))
                                      (range
-                                      ((start 121) (stop 122)
+                                      ((start 115) (stop 122)
                                        (source
                                         (Reader
                                          ((id 0) (name (expect_test.ml))
-                                          (length 146) (unsafe_get <fun>)))))))))
-                                  (range
-                                   ((start 115) (stop 122)
-                                    (source
-                                     (Reader
-                                      ((id 0) (name (expect_test.ml))
-                                       (length 146) (unsafe_get <fun>))))))))))
-                              (range
-                               ((start 109) (stop 123)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 146)
-                                   (unsafe_get <fun>))))))))))
-                          (range
-                           ((start 104) (stop 123)
-                            (source
-                             (Reader
-                              ((id 0) (name (expect_test.ml)) (length 146)
-                               (unsafe_get <fun>))))))))))
-                      (range
-                       ((start 96) (stop 123)
-                        (source
-                         (Reader
-                          ((id 0) (name (expect_test.ml)) (length 146)
-                           (unsafe_get <fun>))))))))))
+                                          (length 146) (unsafe_get <fun>))))))))))
+                                 (range
+                                  ((start 109) (stop 123)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 146)
+                                      (unsafe_get <fun>))))))))))
+                             (range
+                              ((start 104) (stop 123)
+                               (source
+                                (Reader
+                                 ((id 0) (name (expect_test.ml)) (length 146)
+                                  (unsafe_get <fun>))))))))))
+                         (range
+                          ((start 96) (stop 123)
+                           (source
+                            (Reader
+                             ((id 0) (name (expect_test.ml)) (length 146)
+                              (unsafe_get <fun>))))))))))
+                     (range
+                      ((start 43) (stop 125)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 146)
+                          (unsafe_get <fun>)))))))))
                   (range
-                   ((start 43) (stop 125)
+                   ((start 17) (stop 125)
                     (source
                      (Reader
                       ((id 0) (name (expect_test.ml)) (length 146)
                        (unsafe_get <fun>)))))))))
                (range
-                ((start 17) (stop 125)
+                ((start 12) (stop 127)
                  (source
                   (Reader
                    ((id 0) (name (expect_test.ml)) (length 146)
@@ -1400,31 +1410,39 @@ let%expect_test "let : fact" =
               (source
                (Reader
                 ((id 0) (name (expect_test.ml)) (length 97) (unsafe_get <fun>))))))))
-          (value_binding_exp
+          (value_binding_term
            ((it
-             (Exp_app
+             (Term_exp
               ((it
-                (Exp_var
-                 ((it fix)
+                (Exp_app
+                 ((it
+                   (Exp_var
+                    ((it fix)
+                     (range
+                      ((start 12) (stop 15)
+                       (source
+                        (Reader
+                         ((id 0) (name (expect_test.ml)) (length 97)
+                          (unsafe_get <fun>)))))))))
                   (range
                    ((start 12) (stop 15)
                     (source
                      (Reader
                       ((id 0) (name (expect_test.ml)) (length 97)
-                       (unsafe_get <fun>)))))))))
-               (range
-                ((start 12) (stop 15)
-                 (source
-                  (Reader
-                   ((id 0) (name (expect_test.ml)) (length 97)
-                    (unsafe_get <fun>)))))))
-              ((it
-                (Exp_fun
-                 (((it
-                    (Param_mono_val
-                     ((it
-                       (Pat_var
-                        ((it fact)
+                       (unsafe_get <fun>)))))))
+                 ((it
+                   (Exp_fun
+                    (((it
+                       (Param_mono_val
+                        ((it
+                          (Pat_var
+                           ((it fact)
+                            (range
+                             ((start 21) (stop 25)
+                              (source
+                               (Reader
+                                ((id 0) (name (expect_test.ml)) (length 97)
+                                 (unsafe_get <fun>)))))))))
                          (range
                           ((start 21) (stop 25)
                            (source
@@ -1436,18 +1454,18 @@ let%expect_test "let : fact" =
                         (source
                          (Reader
                           ((id 0) (name (expect_test.ml)) (length 97)
-                           (unsafe_get <fun>)))))))))
-                   (range
-                    ((start 21) (stop 25)
-                     (source
-                      (Reader
-                       ((id 0) (name (expect_test.ml)) (length 97)
-                        (unsafe_get <fun>)))))))
-                  ((it
-                    (Param_mono_val
+                           (unsafe_get <fun>)))))))
                      ((it
-                       (Pat_var
-                        ((it n)
+                       (Param_mono_val
+                        ((it
+                          (Pat_var
+                           ((it n)
+                            (range
+                             ((start 26) (stop 27)
+                              (source
+                               (Reader
+                                ((id 0) (name (expect_test.ml)) (length 97)
+                                 (unsafe_get <fun>)))))))))
                          (range
                           ((start 26) (stop 27)
                            (source
@@ -1459,24 +1477,39 @@ let%expect_test "let : fact" =
                         (source
                          (Reader
                           ((id 0) (name (expect_test.ml)) (length 97)
-                           (unsafe_get <fun>)))))))))
-                   (range
-                    ((start 26) (stop 27)
-                     (source
-                      (Reader
-                       ((id 0) (name (expect_test.ml)) (length 97)
-                        (unsafe_get <fun>))))))))
-                 ((it
-                   (Exp_if_then_else
+                           (unsafe_get <fun>))))))))
                     ((it
-                      (Exp_app
+                      (Exp_if_then_else
                        ((it
                          (Exp_app
                           ((it
-                            (Exp_var
-                             ((it "( = )")
+                            (Exp_app
+                             ((it
+                               (Exp_var
+                                ((it "( = )")
+                                 (range
+                                  ((start 45) (stop 46)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 97)
+                                      (unsafe_get <fun>)))))))))
                               (range
-                               ((start 45) (stop 46)
+                               ((start 43) (stop 48)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 97)
+                                   (unsafe_get <fun>)))))))
+                             ((it
+                               (Exp_var
+                                ((it n)
+                                 (range
+                                  ((start 43) (stop 44)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 97)
+                                      (unsafe_get <fun>)))))))))
+                              (range
+                               ((start 43) (stop 44)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 97)
@@ -1487,17 +1520,9 @@ let%expect_test "let : fact" =
                               (Reader
                                ((id 0) (name (expect_test.ml)) (length 97)
                                 (unsafe_get <fun>)))))))
-                          ((it
-                            (Exp_var
-                             ((it n)
-                              (range
-                               ((start 43) (stop 44)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 97)
-                                   (unsafe_get <fun>)))))))))
+                          ((it (Exp_const (Const_int 0)))
                            (range
-                            ((start 43) (stop 44)
+                            ((start 47) (stop 48)
                              (source
                               (Reader
                                ((id 0) (name (expect_test.ml)) (length 97)
@@ -1508,35 +1533,43 @@ let%expect_test "let : fact" =
                            (Reader
                             ((id 0) (name (expect_test.ml)) (length 97)
                              (unsafe_get <fun>)))))))
-                       ((it (Exp_const (Const_int 0)))
+                       ((it (Exp_const (Const_int 1)))
                         (range
-                         ((start 47) (stop 48)
+                         ((start 54) (stop 55)
                           (source
                            (Reader
                             ((id 0) (name (expect_test.ml)) (length 97)
-                             (unsafe_get <fun>)))))))))
-                     (range
-                      ((start 43) (stop 48)
-                       (source
-                        (Reader
-                         ((id 0) (name (expect_test.ml)) (length 97)
-                          (unsafe_get <fun>)))))))
-                    ((it (Exp_const (Const_int 1)))
-                     (range
-                      ((start 54) (stop 55)
-                       (source
-                        (Reader
-                         ((id 0) (name (expect_test.ml)) (length 97)
-                          (unsafe_get <fun>)))))))
-                    ((it
-                      (Exp_app
+                             (unsafe_get <fun>)))))))
                        ((it
                          (Exp_app
                           ((it
-                            (Exp_var
-                             ((it "( * )")
+                            (Exp_app
+                             ((it
+                               (Exp_var
+                                ((it "( * )")
+                                 (range
+                                  ((start 63) (stop 64)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 97)
+                                      (unsafe_get <fun>)))))))))
                               (range
-                               ((start 63) (stop 64)
+                               ((start 61) (stop 77)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 97)
+                                   (unsafe_get <fun>)))))))
+                             ((it
+                               (Exp_var
+                                ((it n)
+                                 (range
+                                  ((start 61) (stop 62)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 97)
+                                      (unsafe_get <fun>)))))))))
+                              (range
+                               ((start 61) (stop 62)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 97)
@@ -1548,52 +1581,52 @@ let%expect_test "let : fact" =
                                ((id 0) (name (expect_test.ml)) (length 97)
                                 (unsafe_get <fun>)))))))
                           ((it
-                            (Exp_var
-                             ((it n)
-                              (range
-                               ((start 61) (stop 62)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 97)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 61) (stop 62)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 97)
-                                (unsafe_get <fun>)))))))))
-                        (range
-                         ((start 61) (stop 77)
-                          (source
-                           (Reader
-                            ((id 0) (name (expect_test.ml)) (length 97)
-                             (unsafe_get <fun>)))))))
-                       ((it
-                         (Exp_app
-                          ((it
-                            (Exp_var
-                             ((it fact)
+                            (Exp_app
+                             ((it
+                               (Exp_var
+                                ((it fact)
+                                 (range
+                                  ((start 65) (stop 69)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 97)
+                                      (unsafe_get <fun>)))))))))
                               (range
                                ((start 65) (stop 69)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 97)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 65) (stop 69)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 97)
-                                (unsafe_get <fun>)))))))
-                          ((it
-                            (Exp_app
+                                   (unsafe_get <fun>)))))))
                              ((it
                                (Exp_app
                                 ((it
-                                  (Exp_var
-                                   ((it "( - )")
+                                  (Exp_app
+                                   ((it
+                                     (Exp_var
+                                      ((it "( - )")
+                                       (range
+                                        ((start 73) (stop 74)
+                                         (source
+                                          (Reader
+                                           ((id 0) (name (expect_test.ml))
+                                            (length 97) (unsafe_get <fun>)))))))))
                                     (range
-                                     ((start 73) (stop 74)
+                                     ((start 71) (stop 76)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 97) (unsafe_get <fun>)))))))
+                                   ((it
+                                     (Exp_var
+                                      ((it n)
+                                       (range
+                                        ((start 71) (stop 72)
+                                         (source
+                                          (Reader
+                                           ((id 0) (name (expect_test.ml))
+                                            (length 97) (unsafe_get <fun>)))))))))
+                                    (range
+                                     ((start 71) (stop 72)
                                       (source
                                        (Reader
                                         ((id 0) (name (expect_test.ml))
@@ -1604,17 +1637,9 @@ let%expect_test "let : fact" =
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 97)
                                       (unsafe_get <fun>)))))))
-                                ((it
-                                  (Exp_var
-                                   ((it n)
-                                    (range
-                                     ((start 71) (stop 72)
-                                      (source
-                                       (Reader
-                                        ((id 0) (name (expect_test.ml))
-                                         (length 97) (unsafe_get <fun>)))))))))
+                                ((it (Exp_const (Const_int 1)))
                                  (range
-                                  ((start 71) (stop 72)
+                                  ((start 75) (stop 76)
                                    (source
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 97)
@@ -1624,40 +1649,33 @@ let%expect_test "let : fact" =
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 97)
-                                   (unsafe_get <fun>)))))))
-                             ((it (Exp_const (Const_int 1)))
-                              (range
-                               ((start 75) (stop 76)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 97)
                                    (unsafe_get <fun>)))))))))
                            (range
-                            ((start 71) (stop 76)
+                            ((start 65) (stop 77)
                              (source
                               (Reader
                                ((id 0) (name (expect_test.ml)) (length 97)
                                 (unsafe_get <fun>)))))))))
                         (range
-                         ((start 65) (stop 77)
+                         ((start 61) (stop 77)
                           (source
                            (Reader
                             ((id 0) (name (expect_test.ml)) (length 97)
                              (unsafe_get <fun>)))))))))
                      (range
-                      ((start 61) (stop 77)
+                      ((start 40) (stop 77)
                        (source
                         (Reader
                          ((id 0) (name (expect_test.ml)) (length 97)
                           (unsafe_get <fun>)))))))))
                   (range
-                   ((start 40) (stop 77)
+                   ((start 17) (stop 77)
                     (source
                      (Reader
                       ((id 0) (name (expect_test.ml)) (length 97)
                        (unsafe_get <fun>)))))))))
                (range
-                ((start 17) (stop 77)
+                ((start 12) (stop 79)
                  (source
                   (Reader
                    ((id 0) (name (expect_test.ml)) (length 97)
@@ -2503,8 +2521,16 @@ let%expect_test "top level function definition" =
                (source
                 (Reader
                  ((id 0) (name (expect_test.ml)) (length 39) (unsafe_get <fun>))))))))
-           (value_binding_exp
-            ((it (Exp_const (Const_int 0)))
+           (value_binding_term
+            ((it
+              (Term_exp
+               ((it (Exp_const (Const_int 0)))
+                (range
+                 ((start 31) (stop 32)
+                  (source
+                   (Reader
+                    ((id 0) (name (expect_test.ml)) (length 39)
+                     (unsafe_get <fun>)))))))))
              (range
               ((start 31) (stop 32)
                (source
@@ -3020,14 +3046,22 @@ let%expect_test "eval example" =
                (source
                 (Reader
                  ((id 0) (name (expect_test.ml)) (length 806) (unsafe_get <fun>))))))))
-           (value_binding_exp
+           (value_binding_term
             ((it
-              (Exp_fun
-               (((it
-                  (Param_mono_val
-                   ((it
-                     (Pat_var
-                      ((it op)
+              (Term_exp
+               ((it
+                 (Exp_fun
+                  (((it
+                     (Param_mono_val
+                      ((it
+                        (Pat_var
+                         ((it op)
+                          (range
+                           ((start 222) (stop 224)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 806)
+                               (unsafe_get <fun>)))))))))
                        (range
                         ((start 222) (stop 224)
                          (source
@@ -3039,18 +3073,18 @@ let%expect_test "eval example" =
                       (source
                        (Reader
                         ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>)))))))))
-                 (range
-                  ((start 222) (stop 224)
-                   (source
-                    (Reader
-                     ((id 0) (name (expect_test.ml)) (length 806)
-                      (unsafe_get <fun>)))))))
-                ((it
-                  (Param_mono_val
+                         (unsafe_get <fun>)))))))
                    ((it
-                     (Pat_var
-                      ((it n1)
+                     (Param_mono_val
+                      ((it
+                        (Pat_var
+                         ((it n1)
+                          (range
+                           ((start 225) (stop 227)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 806)
+                               (unsafe_get <fun>)))))))))
                        (range
                         ((start 225) (stop 227)
                          (source
@@ -3062,18 +3096,18 @@ let%expect_test "eval example" =
                       (source
                        (Reader
                         ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>)))))))))
-                 (range
-                  ((start 225) (stop 227)
-                   (source
-                    (Reader
-                     ((id 0) (name (expect_test.ml)) (length 806)
-                      (unsafe_get <fun>)))))))
-                ((it
-                  (Param_mono_val
+                         (unsafe_get <fun>)))))))
                    ((it
-                     (Pat_var
-                      ((it n2)
+                     (Param_mono_val
+                      ((it
+                        (Pat_var
+                         ((it n2)
+                          (range
+                           ((start 228) (stop 230)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 806)
+                               (unsafe_get <fun>)))))))))
                        (range
                         ((start 228) (stop 230)
                          (source
@@ -3085,58 +3119,73 @@ let%expect_test "eval example" =
                       (source
                        (Reader
                         ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>)))))))))
-                 (range
-                  ((start 228) (stop 230)
-                   (source
-                    (Reader
-                     ((id 0) (name (expect_test.ml)) (length 806)
-                      (unsafe_get <fun>))))))))
-               ((it
-                 (Exp_match
+                         (unsafe_get <fun>))))))))
                   ((it
-                    (Exp_var
-                     ((it op)
+                    (Exp_match
+                     ((it
+                       (Exp_var
+                        ((it op)
+                         (range
+                          ((start 249) (stop 251)
+                           (source
+                            (Reader
+                             ((id 0) (name (expect_test.ml)) (length 806)
+                              (unsafe_get <fun>)))))))))
                       (range
                        ((start 249) (stop 251)
                         (source
                          (Reader
                           ((id 0) (name (expect_test.ml)) (length 806)
-                           (unsafe_get <fun>)))))))))
-                   (range
-                    ((start 249) (stop 251)
-                     (source
-                      (Reader
-                       ((id 0) (name (expect_test.ml)) (length 806)
-                        (unsafe_get <fun>)))))))
-                  (((it
-                     ((case_lhs
-                       ((it
-                         (Pat_constr
-                          ((it Add)
+                           (unsafe_get <fun>)))))))
+                     (((it
+                        ((case_lhs
+                          ((it
+                            (Pat_constr
+                             ((it Add)
+                              (range
+                               ((start 267) (stop 270)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 806)
+                                   (unsafe_get <fun>)))))))
+                             ()))
                            (range
                             ((start 267) (stop 270)
                              (source
                               (Reader
                                ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>)))))))
-                          ()))
-                        (range
-                         ((start 267) (stop 270)
-                          (source
-                           (Reader
-                            ((id 0) (name (expect_test.ml)) (length 806)
-                             (unsafe_get <fun>))))))))
-                      (case_rhs
-                       ((it
-                         (Exp_app
+                                (unsafe_get <fun>))))))))
+                         (case_rhs
                           ((it
                             (Exp_app
                              ((it
-                               (Exp_var
-                                ((it "( + )")
+                               (Exp_app
+                                ((it
+                                  (Exp_var
+                                   ((it "( + )")
+                                    (range
+                                     ((start 277) (stop 278)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 806) (unsafe_get <fun>)))))))))
                                  (range
-                                  ((start 277) (stop 278)
+                                  ((start 274) (stop 281)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                ((it
+                                  (Exp_var
+                                   ((it n1)
+                                    (range
+                                     ((start 274) (stop 276)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 806) (unsafe_get <fun>)))))))))
+                                 (range
+                                  ((start 274) (stop 276)
                                    (source
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 806)
@@ -3149,15 +3198,15 @@ let%expect_test "eval example" =
                                    (unsafe_get <fun>)))))))
                              ((it
                                (Exp_var
-                                ((it n1)
+                                ((it n2)
                                  (range
-                                  ((start 274) (stop 276)
+                                  ((start 279) (stop 281)
                                    (source
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 806)
                                       (unsafe_get <fun>)))))))))
                               (range
-                               ((start 274) (stop 276)
+                               ((start 279) (stop 281)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 806)
@@ -3167,62 +3216,62 @@ let%expect_test "eval example" =
                              (source
                               (Reader
                                ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>)))))))
+                                (unsafe_get <fun>))))))))))
+                       (range
+                        ((start 267) (stop 281)
+                         (source
+                          (Reader
+                           ((id 0) (name (expect_test.ml)) (length 806)
+                            (unsafe_get <fun>)))))))
+                      ((it
+                        ((case_lhs
                           ((it
-                            (Exp_var
-                             ((it n2)
+                            (Pat_constr
+                             ((it Sub)
                               (range
-                               ((start 279) (stop 281)
+                               ((start 292) (stop 295)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 279) (stop 281)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>)))))))))
-                        (range
-                         ((start 274) (stop 281)
-                          (source
-                           (Reader
-                            ((id 0) (name (expect_test.ml)) (length 806)
-                             (unsafe_get <fun>))))))))))
-                    (range
-                     ((start 267) (stop 281)
-                      (source
-                       (Reader
-                        ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>)))))))
-                   ((it
-                     ((case_lhs
-                       ((it
-                         (Pat_constr
-                          ((it Sub)
+                                   (unsafe_get <fun>)))))))
+                             ()))
                            (range
                             ((start 292) (stop 295)
                              (source
                               (Reader
                                ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>)))))))
-                          ()))
-                        (range
-                         ((start 292) (stop 295)
-                          (source
-                           (Reader
-                            ((id 0) (name (expect_test.ml)) (length 806)
-                             (unsafe_get <fun>))))))))
-                      (case_rhs
-                       ((it
-                         (Exp_app
+                                (unsafe_get <fun>))))))))
+                         (case_rhs
                           ((it
                             (Exp_app
                              ((it
-                               (Exp_var
-                                ((it "( - )")
+                               (Exp_app
+                                ((it
+                                  (Exp_var
+                                   ((it "( - )")
+                                    (range
+                                     ((start 302) (stop 303)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 806) (unsafe_get <fun>)))))))))
                                  (range
-                                  ((start 302) (stop 303)
+                                  ((start 299) (stop 306)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                ((it
+                                  (Exp_var
+                                   ((it n1)
+                                    (range
+                                     ((start 299) (stop 301)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 806) (unsafe_get <fun>)))))))))
+                                 (range
+                                  ((start 299) (stop 301)
                                    (source
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 806)
@@ -3235,15 +3284,15 @@ let%expect_test "eval example" =
                                    (unsafe_get <fun>)))))))
                              ((it
                                (Exp_var
-                                ((it n1)
+                                ((it n2)
                                  (range
-                                  ((start 299) (stop 301)
+                                  ((start 304) (stop 306)
                                    (source
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 806)
                                       (unsafe_get <fun>)))))))))
                               (range
-                               ((start 299) (stop 301)
+                               ((start 304) (stop 306)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 806)
@@ -3253,36 +3302,21 @@ let%expect_test "eval example" =
                              (source
                               (Reader
                                ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>)))))))
-                          ((it
-                            (Exp_var
-                             ((it n2)
-                              (range
-                               ((start 304) (stop 306)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 304) (stop 306)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>)))))))))
-                        (range
-                         ((start 299) (stop 306)
-                          (source
-                           (Reader
-                            ((id 0) (name (expect_test.ml)) (length 806)
-                             (unsafe_get <fun>))))))))))
-                    (range
-                     ((start 292) (stop 306)
-                      (source
-                       (Reader
-                        ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>))))))))))
+                                (unsafe_get <fun>))))))))))
+                       (range
+                        ((start 292) (stop 306)
+                         (source
+                          (Reader
+                           ((id 0) (name (expect_test.ml)) (length 806)
+                            (unsafe_get <fun>))))))))))
+                   (range
+                    ((start 243) (stop 316)
+                     (source
+                      (Reader
+                       ((id 0) (name (expect_test.ml)) (length 806)
+                        (unsafe_get <fun>)))))))))
                 (range
-                 ((start 243) (stop 316)
+                 ((start 218) (stop 316)
                   (source
                    (Reader
                     ((id 0) (name (expect_test.ml)) (length 806)
@@ -3320,31 +3354,39 @@ let%expect_test "eval example" =
                (source
                 (Reader
                  ((id 0) (name (expect_test.ml)) (length 806) (unsafe_get <fun>))))))))
-           (value_binding_exp
+           (value_binding_term
             ((it
-              (Exp_app
+              (Term_exp
                ((it
-                 (Exp_var
-                  ((it fix)
+                 (Exp_app
+                  ((it
+                    (Exp_var
+                     ((it fix)
+                      (range
+                       ((start 345) (stop 348)
+                        (source
+                         (Reader
+                          ((id 0) (name (expect_test.ml)) (length 806)
+                           (unsafe_get <fun>)))))))))
                    (range
                     ((start 345) (stop 348)
                      (source
                       (Reader
                        ((id 0) (name (expect_test.ml)) (length 806)
-                        (unsafe_get <fun>)))))))))
-                (range
-                 ((start 345) (stop 348)
-                  (source
-                   (Reader
-                    ((id 0) (name (expect_test.ml)) (length 806)
-                     (unsafe_get <fun>)))))))
-               ((it
-                 (Exp_fun
-                  (((it
-                     (Param_mono_val
-                      ((it
-                        (Pat_var
-                         ((it eval)
+                        (unsafe_get <fun>)))))))
+                  ((it
+                    (Exp_fun
+                     (((it
+                        (Param_mono_val
+                         ((it
+                           (Pat_var
+                            ((it eval)
+                             (range
+                              ((start 354) (stop 358)
+                               (source
+                                (Reader
+                                 ((id 0) (name (expect_test.ml)) (length 806)
+                                  (unsafe_get <fun>)))))))))
                           (range
                            ((start 354) (stop 358)
                             (source
@@ -3356,18 +3398,18 @@ let%expect_test "eval example" =
                          (source
                           (Reader
                            ((id 0) (name (expect_test.ml)) (length 806)
-                            (unsafe_get <fun>)))))))))
-                    (range
-                     ((start 354) (stop 358)
-                      (source
-                       (Reader
-                        ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>)))))))
-                   ((it
-                     (Param_mono_val
+                            (unsafe_get <fun>)))))))
                       ((it
-                        (Pat_var
-                         ((it env)
+                        (Param_mono_val
+                         ((it
+                           (Pat_var
+                            ((it env)
+                             (range
+                              ((start 359) (stop 362)
+                               (source
+                                (Reader
+                                 ((id 0) (name (expect_test.ml)) (length 806)
+                                  (unsafe_get <fun>)))))))))
                           (range
                            ((start 359) (stop 362)
                             (source
@@ -3379,18 +3421,18 @@ let%expect_test "eval example" =
                          (source
                           (Reader
                            ((id 0) (name (expect_test.ml)) (length 806)
-                            (unsafe_get <fun>)))))))))
-                    (range
-                     ((start 359) (stop 362)
-                      (source
-                       (Reader
-                        ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>)))))))
-                   ((it
-                     (Param_mono_val
+                            (unsafe_get <fun>)))))))
                       ((it
-                        (Pat_var
-                         ((it exp)
+                        (Param_mono_val
+                         ((it
+                           (Pat_var
+                            ((it exp)
+                             (range
+                              ((start 363) (stop 366)
+                               (source
+                                (Reader
+                                 ((id 0) (name (expect_test.ml)) (length 806)
+                                  (unsafe_get <fun>)))))))))
                           (range
                            ((start 363) (stop 366)
                             (source
@@ -3402,139 +3444,139 @@ let%expect_test "eval example" =
                          (source
                           (Reader
                            ((id 0) (name (expect_test.ml)) (length 806)
-                            (unsafe_get <fun>)))))))))
-                    (range
-                     ((start 363) (stop 366)
-                      (source
-                       (Reader
-                        ((id 0) (name (expect_test.ml)) (length 806)
-                         (unsafe_get <fun>))))))))
-                  ((it
-                    (Exp_match
+                            (unsafe_get <fun>))))))))
                      ((it
-                       (Exp_var
-                        ((it exp)
+                       (Exp_match
+                        ((it
+                          (Exp_var
+                           ((it exp)
+                            (range
+                             ((start 384) (stop 387)
+                              (source
+                               (Reader
+                                ((id 0) (name (expect_test.ml)) (length 806)
+                                 (unsafe_get <fun>)))))))))
                          (range
                           ((start 384) (stop 387)
                            (source
                             (Reader
                              ((id 0) (name (expect_test.ml)) (length 806)
-                              (unsafe_get <fun>)))))))))
-                      (range
-                       ((start 384) (stop 387)
-                        (source
-                         (Reader
-                          ((id 0) (name (expect_test.ml)) (length 806)
-                           (unsafe_get <fun>)))))))
-                     (((it
-                        ((case_lhs
-                          ((it
-                            (Pat_constr
-                             ((it Int)
-                              (range
-                               ((start 403) (stop 406)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))
-                             (((it
-                                (Pat_var
-                                 ((it n)
+                              (unsafe_get <fun>)))))))
+                        (((it
+                           ((case_lhs
+                             ((it
+                               (Pat_constr
+                                ((it Int)
+                                 (range
+                                  ((start 403) (stop 406)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                (((it
+                                   (Pat_var
+                                    ((it n)
+                                     (range
+                                      ((start 407) (stop 408)
+                                       (source
+                                        (Reader
+                                         ((id 0) (name (expect_test.ml))
+                                          (length 806) (unsafe_get <fun>)))))))))
                                   (range
                                    ((start 407) (stop 408)
                                     (source
                                      (Reader
                                       ((id 0) (name (expect_test.ml))
-                                       (length 806) (unsafe_get <fun>)))))))))
-                               (range
-                                ((start 407) (stop 408)
-                                 (source
-                                  (Reader
-                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                    (unsafe_get <fun>))))))))))
-                           (range
-                            ((start 403) (stop 408)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))
-                         (case_rhs
-                          ((it
-                            (Exp_var
-                             ((it n)
+                                       (length 806) (unsafe_get <fun>))))))))))
+                              (range
+                               ((start 403) (stop 408)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 806)
+                                   (unsafe_get <fun>))))))))
+                            (case_rhs
+                             ((it
+                               (Exp_var
+                                ((it n)
+                                 (range
+                                  ((start 412) (stop 413)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))))
                               (range
                                ((start 412) (stop 413)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 412) (stop 413)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))))
-                       (range
-                        ((start 403) (stop 413)
-                         (source
-                          (Reader
-                           ((id 0) (name (expect_test.ml)) (length 806)
-                            (unsafe_get <fun>)))))))
-                      ((it
-                        ((case_lhs
-                          ((it
-                            (Pat_constr
-                             ((it Var)
-                              (range
-                               ((start 424) (stop 427)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))
-                             (((it
-                                (Pat_var
-                                 ((it x)
+                                   (unsafe_get <fun>))))))))))
+                          (range
+                           ((start 403) (stop 413)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 806)
+                               (unsafe_get <fun>)))))))
+                         ((it
+                           ((case_lhs
+                             ((it
+                               (Pat_constr
+                                ((it Var)
+                                 (range
+                                  ((start 424) (stop 427)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                (((it
+                                   (Pat_var
+                                    ((it x)
+                                     (range
+                                      ((start 428) (stop 429)
+                                       (source
+                                        (Reader
+                                         ((id 0) (name (expect_test.ml))
+                                          (length 806) (unsafe_get <fun>)))))))))
                                   (range
                                    ((start 428) (stop 429)
                                     (source
                                      (Reader
                                       ((id 0) (name (expect_test.ml))
-                                       (length 806) (unsafe_get <fun>)))))))))
-                               (range
-                                ((start 428) (stop 429)
-                                 (source
-                                  (Reader
-                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                    (unsafe_get <fun>))))))))))
-                           (range
-                            ((start 424) (stop 429)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))
-                         (case_rhs
-                          ((it
-                            (Exp_app
+                                       (length 806) (unsafe_get <fun>))))))))))
+                              (range
+                               ((start 424) (stop 429)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 806)
+                                   (unsafe_get <fun>))))))))
+                            (case_rhs
                              ((it
                                (Exp_app
                                 ((it
-                                  (Exp_var
-                                   ((it env_find)
+                                  (Exp_app
+                                   ((it
+                                     (Exp_var
+                                      ((it env_find)
+                                       (range
+                                        ((start 433) (stop 441)
+                                         (source
+                                          (Reader
+                                           ((id 0) (name (expect_test.ml))
+                                            (length 806) (unsafe_get <fun>)))))))))
                                     (range
                                      ((start 433) (stop 441)
                                       (source
                                        (Reader
                                         ((id 0) (name (expect_test.ml))
-                                         (length 806) (unsafe_get <fun>)))))))))
-                                 (range
-                                  ((start 433) (stop 441)
-                                   (source
-                                    (Reader
-                                     ((id 0) (name (expect_test.ml)) (length 806)
-                                      (unsafe_get <fun>)))))))
-                                ((it
-                                  (Exp_var
-                                   ((it env)
+                                         (length 806) (unsafe_get <fun>)))))))
+                                   ((it
+                                     (Exp_var
+                                      ((it env)
+                                       (range
+                                        ((start 442) (stop 445)
+                                         (source
+                                          (Reader
+                                           ((id 0) (name (expect_test.ml))
+                                            (length 806) (unsafe_get <fun>)))))))))
                                     (range
                                      ((start 442) (stop 445)
                                       (source
@@ -3542,20 +3584,20 @@ let%expect_test "eval example" =
                                         ((id 0) (name (expect_test.ml))
                                          (length 806) (unsafe_get <fun>)))))))))
                                  (range
-                                  ((start 442) (stop 445)
+                                  ((start 433) (stop 445)
                                    (source
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 806)
-                                      (unsafe_get <fun>)))))))))
-                              (range
-                               ((start 433) (stop 445)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))
-                             ((it
-                               (Exp_var
-                                ((it x)
+                                      (unsafe_get <fun>)))))))
+                                ((it
+                                  (Exp_var
+                                   ((it x)
+                                    (range
+                                     ((start 446) (stop 447)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 806) (unsafe_get <fun>)))))))))
                                  (range
                                   ((start 446) (stop 447)
                                    (source
@@ -3563,245 +3605,95 @@ let%expect_test "eval example" =
                                      ((id 0) (name (expect_test.ml)) (length 806)
                                       (unsafe_get <fun>)))))))))
                               (range
-                               ((start 446) (stop 447)
+                               ((start 433) (stop 447)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 433) (stop 447)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))))
-                       (range
-                        ((start 424) (stop 447)
-                         (source
-                          (Reader
-                           ((id 0) (name (expect_test.ml)) (length 806)
-                            (unsafe_get <fun>)))))))
-                      ((it
-                        ((case_lhs
-                          ((it
-                            (Pat_constr
-                             ((it Let)
-                              (range
-                               ((start 458) (stop 461)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))
-                             (((it
-                                (Pat_tuple
-                                 (((it
-                                    (Pat_var
-                                     ((it bindings)
+                                   (unsafe_get <fun>))))))))))
+                          (range
+                           ((start 424) (stop 447)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 806)
+                               (unsafe_get <fun>)))))))
+                         ((it
+                           ((case_lhs
+                             ((it
+                               (Pat_constr
+                                ((it Let)
+                                 (range
+                                  ((start 458) (stop 461)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                (((it
+                                   (Pat_tuple
+                                    (((it
+                                       (Pat_var
+                                        ((it bindings)
+                                         (range
+                                          ((start 463) (stop 471)
+                                           (source
+                                            (Reader
+                                             ((id 0) (name (expect_test.ml))
+                                              (length 806) (unsafe_get <fun>)))))))))
                                       (range
                                        ((start 463) (stop 471)
                                         (source
                                          (Reader
                                           ((id 0) (name (expect_test.ml))
-                                           (length 806) (unsafe_get <fun>)))))))))
-                                   (range
-                                    ((start 463) (stop 471)
-                                     (source
-                                      (Reader
-                                       ((id 0) (name (expect_test.ml))
-                                        (length 806) (unsafe_get <fun>)))))))
-                                  ((it
-                                    (Pat_var
-                                     ((it in_)
+                                           (length 806) (unsafe_get <fun>)))))))
+                                     ((it
+                                       (Pat_var
+                                        ((it in_)
+                                         (range
+                                          ((start 473) (stop 476)
+                                           (source
+                                            (Reader
+                                             ((id 0) (name (expect_test.ml))
+                                              (length 806) (unsafe_get <fun>)))))))))
                                       (range
                                        ((start 473) (stop 476)
                                         (source
                                          (Reader
                                           ((id 0) (name (expect_test.ml))
-                                           (length 806) (unsafe_get <fun>)))))))))
-                                   (range
-                                    ((start 473) (stop 476)
-                                     (source
-                                      (Reader
-                                       ((id 0) (name (expect_test.ml))
-                                        (length 806) (unsafe_get <fun>))))))))))
-                               (range
-                                ((start 462) (stop 477)
-                                 (source
-                                  (Reader
-                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                    (unsafe_get <fun>))))))))))
-                           (range
-                            ((start 458) (stop 477)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))
-                         (case_rhs
-                          ((it
-                            (Exp_let
-                             ((it
-                               ((value_binding_pat
-                                 ((it
-                                   (Pat_var
-                                    ((it env)
-                                     (range
-                                      ((start 496) (stop 499)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>)))))))))
+                                           (length 806) (unsafe_get <fun>))))))))))
                                   (range
-                                   ((start 496) (stop 499)
+                                   ((start 462) (stop 477)
                                     (source
                                      (Reader
                                       ((id 0) (name (expect_test.ml))
-                                       (length 806) (unsafe_get <fun>))))))))
-                                (value_binding_exp
-                                 ((it
-                                   (Exp_app
+                                       (length 806) (unsafe_get <fun>))))))))))
+                              (range
+                               ((start 458) (stop 477)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 806)
+                                   (unsafe_get <fun>))))))))
+                            (case_rhs
+                             ((it
+                               (Exp_let
+                                ((it
+                                  ((value_binding_pat
                                     ((it
-                                      (Exp_app
-                                       ((it
-                                         (Exp_app
-                                          ((it
-                                            (Exp_var
-                                             ((it list_fold_right)
-                                              (range
-                                               ((start 515) (stop 530)
-                                                (source
-                                                 (Reader
-                                                  ((id 0) (name (expect_test.ml))
-                                                   (length 806)
-                                                   (unsafe_get <fun>)))))))))
-                                           (range
-                                            ((start 515) (stop 530)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))
-                                          ((it
-                                            (Exp_var
-                                             ((it bindings)
-                                              (range
-                                               ((start 531) (stop 539)
-                                                (source
-                                                 (Reader
-                                                  ((id 0) (name (expect_test.ml))
-                                                   (length 806)
-                                                   (unsafe_get <fun>)))))))))
-                                           (range
-                                            ((start 531) (stop 539)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))))
+                                      (Pat_var
+                                       ((it env)
                                         (range
-                                         ((start 515) (stop 539)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))
-                                       ((it
-                                         (Exp_var
-                                          ((it env)
-                                           (range
-                                            ((start 540) (stop 543)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))))
-                                        (range
-                                         ((start 540) (stop 543)
+                                         ((start 496) (stop 499)
                                           (source
                                            (Reader
                                             ((id 0) (name (expect_test.ml))
                                              (length 806) (unsafe_get <fun>)))))))))
                                      (range
-                                      ((start 515) (stop 543)
+                                      ((start 496) (stop 499)
                                        (source
                                         (Reader
                                          ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>)))))))
+                                          (length 806) (unsafe_get <fun>))))))))
+                                   (value_binding_term
                                     ((it
-                                      (Exp_fun
-                                       (((it
-                                          (Param_mono_val
-                                           ((it
-                                             (Pat_tuple
-                                              (((it
-                                                 (Pat_var
-                                                  ((it var)
-                                                   (range
-                                                    ((start 550) (stop 553)
-                                                     (source
-                                                      (Reader
-                                                       ((id 0)
-                                                        (name (expect_test.ml))
-                                                        (length 806)
-                                                        (unsafe_get <fun>)))))))))
-                                                (range
-                                                 ((start 550) (stop 553)
-                                                  (source
-                                                   (Reader
-                                                    ((id 0)
-                                                     (name (expect_test.ml))
-                                                     (length 806)
-                                                     (unsafe_get <fun>)))))))
-                                               ((it
-                                                 (Pat_var
-                                                  ((it exp)
-                                                   (range
-                                                    ((start 555) (stop 558)
-                                                     (source
-                                                      (Reader
-                                                       ((id 0)
-                                                        (name (expect_test.ml))
-                                                        (length 806)
-                                                        (unsafe_get <fun>)))))))))
-                                                (range
-                                                 ((start 555) (stop 558)
-                                                  (source
-                                                   (Reader
-                                                    ((id 0)
-                                                     (name (expect_test.ml))
-                                                     (length 806)
-                                                     (unsafe_get <fun>))))))))))
-                                            (range
-                                             ((start 549) (stop 559)
-                                              (source
-                                               (Reader
-                                                ((id 0) (name (expect_test.ml))
-                                                 (length 806) (unsafe_get <fun>)))))))))
-                                         (range
-                                          ((start 549) (stop 559)
-                                           (source
-                                            (Reader
-                                             ((id 0) (name (expect_test.ml))
-                                              (length 806) (unsafe_get <fun>)))))))
-                                        ((it
-                                          (Param_mono_val
-                                           ((it
-                                             (Pat_var
-                                              ((it env)
-                                               (range
-                                                ((start 560) (stop 563)
-                                                 (source
-                                                  (Reader
-                                                   ((id 0)
-                                                    (name (expect_test.ml))
-                                                    (length 806)
-                                                    (unsafe_get <fun>)))))))))
-                                            (range
-                                             ((start 560) (stop 563)
-                                              (source
-                                               (Reader
-                                                ((id 0) (name (expect_test.ml))
-                                                 (length 806) (unsafe_get <fun>)))))))))
-                                         (range
-                                          ((start 560) (stop 563)
-                                           (source
-                                            (Reader
-                                             ((id 0) (name (expect_test.ml))
-                                              (length 806) (unsafe_get <fun>))))))))
+                                      (Term_exp
                                        ((it
                                          (Exp_app
                                           ((it
@@ -3810,9 +3702,9 @@ let%expect_test "eval example" =
                                                (Exp_app
                                                 ((it
                                                   (Exp_var
-                                                   ((it env_bind)
+                                                   ((it list_fold_right)
                                                     (range
-                                                     ((start 581) (stop 589)
+                                                     ((start 515) (stop 530)
                                                       (source
                                                        (Reader
                                                         ((id 0)
@@ -3820,7 +3712,577 @@ let%expect_test "eval example" =
                                                          (length 806)
                                                          (unsafe_get <fun>)))))))))
                                                  (range
-                                                  ((start 581) (stop 589)
+                                                  ((start 515) (stop 530)
+                                                   (source
+                                                    (Reader
+                                                     ((id 0)
+                                                      (name (expect_test.ml))
+                                                      (length 806)
+                                                      (unsafe_get <fun>)))))))
+                                                ((it
+                                                  (Exp_var
+                                                   ((it bindings)
+                                                    (range
+                                                     ((start 531) (stop 539)
+                                                      (source
+                                                       (Reader
+                                                        ((id 0)
+                                                         (name (expect_test.ml))
+                                                         (length 806)
+                                                         (unsafe_get <fun>)))))))))
+                                                 (range
+                                                  ((start 531) (stop 539)
+                                                   (source
+                                                    (Reader
+                                                     ((id 0)
+                                                      (name (expect_test.ml))
+                                                      (length 806)
+                                                      (unsafe_get <fun>)))))))))
+                                              (range
+                                               ((start 515) (stop 539)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 806)
+                                                   (unsafe_get <fun>)))))))
+                                             ((it
+                                               (Exp_var
+                                                ((it env)
+                                                 (range
+                                                  ((start 540) (stop 543)
+                                                   (source
+                                                    (Reader
+                                                     ((id 0)
+                                                      (name (expect_test.ml))
+                                                      (length 806)
+                                                      (unsafe_get <fun>)))))))))
+                                              (range
+                                               ((start 540) (stop 543)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 806)
+                                                   (unsafe_get <fun>)))))))))
+                                           (range
+                                            ((start 515) (stop 543)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 806) (unsafe_get <fun>)))))))
+                                          ((it
+                                            (Exp_fun
+                                             (((it
+                                                (Param_mono_val
+                                                 ((it
+                                                   (Pat_tuple
+                                                    (((it
+                                                       (Pat_var
+                                                        ((it var)
+                                                         (range
+                                                          ((start 550) (stop 553)
+                                                           (source
+                                                            (Reader
+                                                             ((id 0)
+                                                              (name
+                                                               (expect_test.ml))
+                                                              (length 806)
+                                                              (unsafe_get <fun>)))))))))
+                                                      (range
+                                                       ((start 550) (stop 553)
+                                                        (source
+                                                         (Reader
+                                                          ((id 0)
+                                                           (name
+                                                            (expect_test.ml))
+                                                           (length 806)
+                                                           (unsafe_get <fun>)))))))
+                                                     ((it
+                                                       (Pat_var
+                                                        ((it exp)
+                                                         (range
+                                                          ((start 555) (stop 558)
+                                                           (source
+                                                            (Reader
+                                                             ((id 0)
+                                                              (name
+                                                               (expect_test.ml))
+                                                              (length 806)
+                                                              (unsafe_get <fun>)))))))))
+                                                      (range
+                                                       ((start 555) (stop 558)
+                                                        (source
+                                                         (Reader
+                                                          ((id 0)
+                                                           (name
+                                                            (expect_test.ml))
+                                                           (length 806)
+                                                           (unsafe_get <fun>))))))))))
+                                                  (range
+                                                   ((start 549) (stop 559)
+                                                    (source
+                                                     (Reader
+                                                      ((id 0)
+                                                       (name (expect_test.ml))
+                                                       (length 806)
+                                                       (unsafe_get <fun>)))))))))
+                                               (range
+                                                ((start 549) (stop 559)
+                                                 (source
+                                                  (Reader
+                                                   ((id 0)
+                                                    (name (expect_test.ml))
+                                                    (length 806)
+                                                    (unsafe_get <fun>)))))))
+                                              ((it
+                                                (Param_mono_val
+                                                 ((it
+                                                   (Pat_var
+                                                    ((it env)
+                                                     (range
+                                                      ((start 560) (stop 563)
+                                                       (source
+                                                        (Reader
+                                                         ((id 0)
+                                                          (name (expect_test.ml))
+                                                          (length 806)
+                                                          (unsafe_get <fun>)))))))))
+                                                  (range
+                                                   ((start 560) (stop 563)
+                                                    (source
+                                                     (Reader
+                                                      ((id 0)
+                                                       (name (expect_test.ml))
+                                                       (length 806)
+                                                       (unsafe_get <fun>)))))))))
+                                               (range
+                                                ((start 560) (stop 563)
+                                                 (source
+                                                  (Reader
+                                                   ((id 0)
+                                                    (name (expect_test.ml))
+                                                    (length 806)
+                                                    (unsafe_get <fun>))))))))
+                                             ((it
+                                               (Exp_app
+                                                ((it
+                                                  (Exp_app
+                                                   ((it
+                                                     (Exp_app
+                                                      ((it
+                                                        (Exp_var
+                                                         ((it env_bind)
+                                                          (range
+                                                           ((start 581)
+                                                            (stop 589)
+                                                            (source
+                                                             (Reader
+                                                              ((id 0)
+                                                               (name
+                                                                (expect_test.ml))
+                                                               (length 806)
+                                                               (unsafe_get <fun>)))))))))
+                                                       (range
+                                                        ((start 581) (stop 589)
+                                                         (source
+                                                          (Reader
+                                                           ((id 0)
+                                                            (name
+                                                             (expect_test.ml))
+                                                            (length 806)
+                                                            (unsafe_get <fun>)))))))
+                                                      ((it
+                                                        (Exp_var
+                                                         ((it env)
+                                                          (range
+                                                           ((start 590)
+                                                            (stop 593)
+                                                            (source
+                                                             (Reader
+                                                              ((id 0)
+                                                               (name
+                                                                (expect_test.ml))
+                                                               (length 806)
+                                                               (unsafe_get <fun>)))))))))
+                                                       (range
+                                                        ((start 590) (stop 593)
+                                                         (source
+                                                          (Reader
+                                                           ((id 0)
+                                                            (name
+                                                             (expect_test.ml))
+                                                            (length 806)
+                                                            (unsafe_get <fun>)))))))))
+                                                    (range
+                                                     ((start 581) (stop 593)
+                                                      (source
+                                                       (Reader
+                                                        ((id 0)
+                                                         (name (expect_test.ml))
+                                                         (length 806)
+                                                         (unsafe_get <fun>)))))))
+                                                   ((it
+                                                     (Exp_var
+                                                      ((it var)
+                                                       (range
+                                                        ((start 594) (stop 597)
+                                                         (source
+                                                          (Reader
+                                                           ((id 0)
+                                                            (name
+                                                             (expect_test.ml))
+                                                            (length 806)
+                                                            (unsafe_get <fun>)))))))))
+                                                    (range
+                                                     ((start 594) (stop 597)
+                                                      (source
+                                                       (Reader
+                                                        ((id 0)
+                                                         (name (expect_test.ml))
+                                                         (length 806)
+                                                         (unsafe_get <fun>)))))))))
+                                                 (range
+                                                  ((start 581) (stop 597)
+                                                   (source
+                                                    (Reader
+                                                     ((id 0)
+                                                      (name (expect_test.ml))
+                                                      (length 806)
+                                                      (unsafe_get <fun>)))))))
+                                                ((it
+                                                  (Exp_var
+                                                   ((it exp)
+                                                    (range
+                                                     ((start 598) (stop 601)
+                                                      (source
+                                                       (Reader
+                                                        ((id 0)
+                                                         (name (expect_test.ml))
+                                                         (length 806)
+                                                         (unsafe_get <fun>)))))))))
+                                                 (range
+                                                  ((start 598) (stop 601)
+                                                   (source
+                                                    (Reader
+                                                     ((id 0)
+                                                      (name (expect_test.ml))
+                                                      (length 806)
+                                                      (unsafe_get <fun>)))))))))
+                                              (range
+                                               ((start 581) (stop 601)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 806)
+                                                   (unsafe_get <fun>)))))))))
+                                           (range
+                                            ((start 545) (stop 601)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 806) (unsafe_get <fun>)))))))))
+                                        (range
+                                         ((start 515) (stop 602)
+                                          (source
+                                           (Reader
+                                            ((id 0) (name (expect_test.ml))
+                                             (length 806) (unsafe_get <fun>)))))))))
+                                     (range
+                                      ((start 515) (stop 602)
+                                       (source
+                                        (Reader
+                                         ((id 0) (name (expect_test.ml))
+                                          (length 806) (unsafe_get <fun>))))))))))
+                                 (range
+                                  ((start 496) (stop 602)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                ((it
+                                  (Exp_app
+                                   ((it
+                                     (Exp_app
+                                      ((it
+                                        (Exp_var
+                                         ((it eval)
+                                          (range
+                                           ((start 627) (stop 631)
+                                            (source
+                                             (Reader
+                                              ((id 0) (name (expect_test.ml))
+                                               (length 806) (unsafe_get <fun>)))))))))
+                                       (range
+                                        ((start 627) (stop 631)
+                                         (source
+                                          (Reader
+                                           ((id 0) (name (expect_test.ml))
+                                            (length 806) (unsafe_get <fun>)))))))
+                                      ((it
+                                        (Exp_var
+                                         ((it env)
+                                          (range
+                                           ((start 632) (stop 635)
+                                            (source
+                                             (Reader
+                                              ((id 0) (name (expect_test.ml))
+                                               (length 806) (unsafe_get <fun>)))))))))
+                                       (range
+                                        ((start 632) (stop 635)
+                                         (source
+                                          (Reader
+                                           ((id 0) (name (expect_test.ml))
+                                            (length 806) (unsafe_get <fun>)))))))))
+                                    (range
+                                     ((start 627) (stop 635)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 806) (unsafe_get <fun>)))))))
+                                   ((it
+                                     (Exp_var
+                                      ((it in_)
+                                       (range
+                                        ((start 636) (stop 639)
+                                         (source
+                                          (Reader
+                                           ((id 0) (name (expect_test.ml))
+                                            (length 806) (unsafe_get <fun>)))))))))
+                                    (range
+                                     ((start 636) (stop 639)
+                                      (source
+                                       (Reader
+                                        ((id 0) (name (expect_test.ml))
+                                         (length 806) (unsafe_get <fun>)))))))))
+                                 (range
+                                  ((start 627) (stop 639)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))))
+                              (range
+                               ((start 492) (stop 639)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 806)
+                                   (unsafe_get <fun>))))))))))
+                          (range
+                           ((start 458) (stop 639)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 806)
+                               (unsafe_get <fun>)))))))
+                         ((it
+                           ((case_lhs
+                             ((it
+                               (Pat_constr
+                                ((it Bin_op)
+                                 (range
+                                  ((start 650) (stop 656)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                (((it
+                                   (Pat_tuple
+                                    (((it
+                                       (Pat_var
+                                        ((it left)
+                                         (range
+                                          ((start 658) (stop 662)
+                                           (source
+                                            (Reader
+                                             ((id 0) (name (expect_test.ml))
+                                              (length 806) (unsafe_get <fun>)))))))))
+                                      (range
+                                       ((start 658) (stop 662)
+                                        (source
+                                         (Reader
+                                          ((id 0) (name (expect_test.ml))
+                                           (length 806) (unsafe_get <fun>)))))))
+                                     ((it
+                                       (Pat_var
+                                        ((it op)
+                                         (range
+                                          ((start 664) (stop 666)
+                                           (source
+                                            (Reader
+                                             ((id 0) (name (expect_test.ml))
+                                              (length 806) (unsafe_get <fun>)))))))))
+                                      (range
+                                       ((start 664) (stop 666)
+                                        (source
+                                         (Reader
+                                          ((id 0) (name (expect_test.ml))
+                                           (length 806) (unsafe_get <fun>)))))))
+                                     ((it
+                                       (Pat_var
+                                        ((it right)
+                                         (range
+                                          ((start 668) (stop 673)
+                                           (source
+                                            (Reader
+                                             ((id 0) (name (expect_test.ml))
+                                              (length 806) (unsafe_get <fun>)))))))))
+                                      (range
+                                       ((start 668) (stop 673)
+                                        (source
+                                         (Reader
+                                          ((id 0) (name (expect_test.ml))
+                                           (length 806) (unsafe_get <fun>))))))))))
+                                  (range
+                                   ((start 657) (stop 674)
+                                    (source
+                                     (Reader
+                                      ((id 0) (name (expect_test.ml))
+                                       (length 806) (unsafe_get <fun>))))))))))
+                              (range
+                               ((start 650) (stop 674)
+                                (source
+                                 (Reader
+                                  ((id 0) (name (expect_test.ml)) (length 806)
+                                   (unsafe_get <fun>))))))))
+                            (case_rhs
+                             ((it
+                               (Exp_let
+                                ((it
+                                  ((value_binding_pat
+                                    ((it
+                                      (Pat_var
+                                       ((it n1)
+                                        (range
+                                         ((start 692) (stop 694)
+                                          (source
+                                           (Reader
+                                            ((id 0) (name (expect_test.ml))
+                                             (length 806) (unsafe_get <fun>)))))))))
+                                     (range
+                                      ((start 692) (stop 694)
+                                       (source
+                                        (Reader
+                                         ((id 0) (name (expect_test.ml))
+                                          (length 806) (unsafe_get <fun>))))))))
+                                   (value_binding_term
+                                    ((it
+                                      (Term_exp
+                                       ((it
+                                         (Exp_app
+                                          ((it
+                                            (Exp_app
+                                             ((it
+                                               (Exp_var
+                                                ((it eval)
+                                                 (range
+                                                  ((start 697) (stop 701)
+                                                   (source
+                                                    (Reader
+                                                     ((id 0)
+                                                      (name (expect_test.ml))
+                                                      (length 806)
+                                                      (unsafe_get <fun>)))))))))
+                                              (range
+                                               ((start 697) (stop 701)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 806)
+                                                   (unsafe_get <fun>)))))))
+                                             ((it
+                                               (Exp_var
+                                                ((it env)
+                                                 (range
+                                                  ((start 702) (stop 705)
+                                                   (source
+                                                    (Reader
+                                                     ((id 0)
+                                                      (name (expect_test.ml))
+                                                      (length 806)
+                                                      (unsafe_get <fun>)))))))))
+                                              (range
+                                               ((start 702) (stop 705)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 806)
+                                                   (unsafe_get <fun>)))))))))
+                                           (range
+                                            ((start 697) (stop 705)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 806) (unsafe_get <fun>)))))))
+                                          ((it
+                                            (Exp_var
+                                             ((it left)
+                                              (range
+                                               ((start 706) (stop 710)
+                                                (source
+                                                 (Reader
+                                                  ((id 0) (name (expect_test.ml))
+                                                   (length 806)
+                                                   (unsafe_get <fun>)))))))))
+                                           (range
+                                            ((start 706) (stop 710)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 806) (unsafe_get <fun>)))))))))
+                                        (range
+                                         ((start 697) (stop 710)
+                                          (source
+                                           (Reader
+                                            ((id 0) (name (expect_test.ml))
+                                             (length 806) (unsafe_get <fun>)))))))))
+                                     (range
+                                      ((start 697) (stop 710)
+                                       (source
+                                        (Reader
+                                         ((id 0) (name (expect_test.ml))
+                                          (length 806) (unsafe_get <fun>))))))))))
+                                 (range
+                                  ((start 692) (stop 710)
+                                   (source
+                                    (Reader
+                                     ((id 0) (name (expect_test.ml)) (length 806)
+                                      (unsafe_get <fun>)))))))
+                                ((it
+                                  (Exp_let
+                                   ((it
+                                     ((value_binding_pat
+                                       ((it
+                                         (Pat_var
+                                          ((it n2)
+                                           (range
+                                            ((start 728) (stop 730)
+                                             (source
+                                              (Reader
+                                               ((id 0) (name (expect_test.ml))
+                                                (length 806) (unsafe_get <fun>)))))))))
+                                        (range
+                                         ((start 728) (stop 730)
+                                          (source
+                                           (Reader
+                                            ((id 0) (name (expect_test.ml))
+                                             (length 806) (unsafe_get <fun>))))))))
+                                      (value_binding_term
+                                       ((it
+                                         (Term_exp
+                                          ((it
+                                            (Exp_app
+                                             ((it
+                                               (Exp_app
+                                                ((it
+                                                  (Exp_var
+                                                   ((it eval)
+                                                    (range
+                                                     ((start 733) (stop 737)
+                                                      (source
+                                                       (Reader
+                                                        ((id 0)
+                                                         (name (expect_test.ml))
+                                                         (length 806)
+                                                         (unsafe_get <fun>)))))))))
+                                                 (range
+                                                  ((start 733) (stop 737)
                                                    (source
                                                     (Reader
                                                      ((id 0)
@@ -3831,7 +4293,7 @@ let%expect_test "eval example" =
                                                   (Exp_var
                                                    ((it env)
                                                     (range
-                                                     ((start 590) (stop 593)
+                                                     ((start 738) (stop 741)
                                                       (source
                                                        (Reader
                                                         ((id 0)
@@ -3839,7 +4301,7 @@ let%expect_test "eval example" =
                                                          (length 806)
                                                          (unsafe_get <fun>)))))))))
                                                  (range
-                                                  ((start 590) (stop 593)
+                                                  ((start 738) (stop 741)
                                                    (source
                                                     (Reader
                                                      ((id 0)
@@ -3847,7 +4309,7 @@ let%expect_test "eval example" =
                                                       (length 806)
                                                       (unsafe_get <fun>)))))))))
                                               (range
-                                               ((start 581) (stop 593)
+                                               ((start 733) (stop 741)
                                                 (source
                                                  (Reader
                                                   ((id 0) (name (expect_test.ml))
@@ -3855,9 +4317,9 @@ let%expect_test "eval example" =
                                                    (unsafe_get <fun>)))))))
                                              ((it
                                                (Exp_var
-                                                ((it var)
+                                                ((it right)
                                                  (range
-                                                  ((start 594) (stop 597)
+                                                  ((start 742) (stop 747)
                                                    (source
                                                     (Reader
                                                      ((id 0)
@@ -3865,403 +4327,65 @@ let%expect_test "eval example" =
                                                       (length 806)
                                                       (unsafe_get <fun>)))))))))
                                               (range
-                                               ((start 594) (stop 597)
+                                               ((start 742) (stop 747)
                                                 (source
                                                  (Reader
                                                   ((id 0) (name (expect_test.ml))
                                                    (length 806)
                                                    (unsafe_get <fun>)))))))))
                                            (range
-                                            ((start 581) (stop 597)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))
-                                          ((it
-                                            (Exp_var
-                                             ((it exp)
-                                              (range
-                                               ((start 598) (stop 601)
-                                                (source
-                                                 (Reader
-                                                  ((id 0) (name (expect_test.ml))
-                                                   (length 806)
-                                                   (unsafe_get <fun>)))))))))
-                                           (range
-                                            ((start 598) (stop 601)
+                                            ((start 733) (stop 747)
                                              (source
                                               (Reader
                                                ((id 0) (name (expect_test.ml))
                                                 (length 806) (unsafe_get <fun>)))))))))
                                         (range
-                                         ((start 581) (stop 601)
+                                         ((start 733) (stop 747)
                                           (source
                                            (Reader
                                             ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))))
-                                     (range
-                                      ((start 545) (stop 601)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>)))))))))
-                                  (range
-                                   ((start 515) (stop 602)
-                                    (source
-                                     (Reader
-                                      ((id 0) (name (expect_test.ml))
-                                       (length 806) (unsafe_get <fun>))))))))))
-                              (range
-                               ((start 496) (stop 602)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))
-                             ((it
-                               (Exp_app
-                                ((it
-                                  (Exp_app
-                                   ((it
-                                     (Exp_var
-                                      ((it eval)
-                                       (range
-                                        ((start 627) (stop 631)
-                                         (source
-                                          (Reader
-                                           ((id 0) (name (expect_test.ml))
-                                            (length 806) (unsafe_get <fun>)))))))))
+                                             (length 806) (unsafe_get <fun>))))))))))
                                     (range
-                                     ((start 627) (stop 631)
+                                     ((start 728) (stop 747)
                                       (source
                                        (Reader
                                         ((id 0) (name (expect_test.ml))
                                          (length 806) (unsafe_get <fun>)))))))
                                    ((it
-                                     (Exp_var
-                                      ((it env)
-                                       (range
-                                        ((start 632) (stop 635)
-                                         (source
-                                          (Reader
-                                           ((id 0) (name (expect_test.ml))
-                                            (length 806) (unsafe_get <fun>)))))))))
-                                    (range
-                                     ((start 632) (stop 635)
-                                      (source
-                                       (Reader
-                                        ((id 0) (name (expect_test.ml))
-                                         (length 806) (unsafe_get <fun>)))))))))
-                                 (range
-                                  ((start 627) (stop 635)
-                                   (source
-                                    (Reader
-                                     ((id 0) (name (expect_test.ml)) (length 806)
-                                      (unsafe_get <fun>)))))))
-                                ((it
-                                  (Exp_var
-                                   ((it in_)
-                                    (range
-                                     ((start 636) (stop 639)
-                                      (source
-                                       (Reader
-                                        ((id 0) (name (expect_test.ml))
-                                         (length 806) (unsafe_get <fun>)))))))))
-                                 (range
-                                  ((start 636) (stop 639)
-                                   (source
-                                    (Reader
-                                     ((id 0) (name (expect_test.ml)) (length 806)
-                                      (unsafe_get <fun>)))))))))
-                              (range
-                               ((start 627) (stop 639)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 492) (stop 639)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))))
-                       (range
-                        ((start 458) (stop 639)
-                         (source
-                          (Reader
-                           ((id 0) (name (expect_test.ml)) (length 806)
-                            (unsafe_get <fun>)))))))
-                      ((it
-                        ((case_lhs
-                          ((it
-                            (Pat_constr
-                             ((it Bin_op)
-                              (range
-                               ((start 650) (stop 656)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))
-                             (((it
-                                (Pat_tuple
-                                 (((it
-                                    (Pat_var
-                                     ((it left)
-                                      (range
-                                       ((start 658) (stop 662)
-                                        (source
-                                         (Reader
-                                          ((id 0) (name (expect_test.ml))
-                                           (length 806) (unsafe_get <fun>)))))))))
-                                   (range
-                                    ((start 658) (stop 662)
-                                     (source
-                                      (Reader
-                                       ((id 0) (name (expect_test.ml))
-                                        (length 806) (unsafe_get <fun>)))))))
-                                  ((it
-                                    (Pat_var
-                                     ((it op)
-                                      (range
-                                       ((start 664) (stop 666)
-                                        (source
-                                         (Reader
-                                          ((id 0) (name (expect_test.ml))
-                                           (length 806) (unsafe_get <fun>)))))))))
-                                   (range
-                                    ((start 664) (stop 666)
-                                     (source
-                                      (Reader
-                                       ((id 0) (name (expect_test.ml))
-                                        (length 806) (unsafe_get <fun>)))))))
-                                  ((it
-                                    (Pat_var
-                                     ((it right)
-                                      (range
-                                       ((start 668) (stop 673)
-                                        (source
-                                         (Reader
-                                          ((id 0) (name (expect_test.ml))
-                                           (length 806) (unsafe_get <fun>)))))))))
-                                   (range
-                                    ((start 668) (stop 673)
-                                     (source
-                                      (Reader
-                                       ((id 0) (name (expect_test.ml))
-                                        (length 806) (unsafe_get <fun>))))))))))
-                               (range
-                                ((start 657) (stop 674)
-                                 (source
-                                  (Reader
-                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                    (unsafe_get <fun>))))))))))
-                           (range
-                            ((start 650) (stop 674)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))
-                         (case_rhs
-                          ((it
-                            (Exp_let
-                             ((it
-                               ((value_binding_pat
-                                 ((it
-                                   (Pat_var
-                                    ((it n1)
-                                     (range
-                                      ((start 692) (stop 694)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>)))))))))
-                                  (range
-                                   ((start 692) (stop 694)
-                                    (source
-                                     (Reader
-                                      ((id 0) (name (expect_test.ml))
-                                       (length 806) (unsafe_get <fun>))))))))
-                                (value_binding_exp
-                                 ((it
-                                   (Exp_app
-                                    ((it
-                                      (Exp_app
-                                       ((it
-                                         (Exp_var
-                                          ((it eval)
-                                           (range
-                                            ((start 697) (stop 701)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))))
-                                        (range
-                                         ((start 697) (stop 701)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))
-                                       ((it
-                                         (Exp_var
-                                          ((it env)
-                                           (range
-                                            ((start 702) (stop 705)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))))
-                                        (range
-                                         ((start 702) (stop 705)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))))
-                                     (range
-                                      ((start 697) (stop 705)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>)))))))
-                                    ((it
-                                      (Exp_var
-                                       ((it left)
-                                        (range
-                                         ((start 706) (stop 710)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))))
-                                     (range
-                                      ((start 706) (stop 710)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>)))))))))
-                                  (range
-                                   ((start 697) (stop 710)
-                                    (source
-                                     (Reader
-                                      ((id 0) (name (expect_test.ml))
-                                       (length 806) (unsafe_get <fun>))))))))))
-                              (range
-                               ((start 692) (stop 710)
-                                (source
-                                 (Reader
-                                  ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))
-                             ((it
-                               (Exp_let
-                                ((it
-                                  ((value_binding_pat
-                                    ((it
-                                      (Pat_var
-                                       ((it n2)
-                                        (range
-                                         ((start 728) (stop 730)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))))
-                                     (range
-                                      ((start 728) (stop 730)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>))))))))
-                                   (value_binding_exp
-                                    ((it
-                                      (Exp_app
-                                       ((it
-                                         (Exp_app
-                                          ((it
-                                            (Exp_var
-                                             ((it eval)
-                                              (range
-                                               ((start 733) (stop 737)
-                                                (source
-                                                 (Reader
-                                                  ((id 0) (name (expect_test.ml))
-                                                   (length 806)
-                                                   (unsafe_get <fun>)))))))))
-                                           (range
-                                            ((start 733) (stop 737)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))
-                                          ((it
-                                            (Exp_var
-                                             ((it env)
-                                              (range
-                                               ((start 738) (stop 741)
-                                                (source
-                                                 (Reader
-                                                  ((id 0) (name (expect_test.ml))
-                                                   (length 806)
-                                                   (unsafe_get <fun>)))))))))
-                                           (range
-                                            ((start 738) (stop 741)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))))
-                                        (range
-                                         ((start 733) (stop 741)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))
-                                       ((it
-                                         (Exp_var
-                                          ((it right)
-                                           (range
-                                            ((start 742) (stop 747)
-                                             (source
-                                              (Reader
-                                               ((id 0) (name (expect_test.ml))
-                                                (length 806) (unsafe_get <fun>)))))))))
-                                        (range
-                                         ((start 742) (stop 747)
-                                          (source
-                                           (Reader
-                                            ((id 0) (name (expect_test.ml))
-                                             (length 806) (unsafe_get <fun>)))))))))
-                                     (range
-                                      ((start 733) (stop 747)
-                                       (source
-                                        (Reader
-                                         ((id 0) (name (expect_test.ml))
-                                          (length 806) (unsafe_get <fun>))))))))))
-                                 (range
-                                  ((start 728) (stop 747)
-                                   (source
-                                    (Reader
-                                     ((id 0) (name (expect_test.ml)) (length 806)
-                                      (unsafe_get <fun>)))))))
-                                ((it
-                                  (Exp_app
-                                   ((it
                                      (Exp_app
                                       ((it
                                         (Exp_app
                                          ((it
-                                           (Exp_var
-                                            ((it eval_bin_op)
+                                           (Exp_app
+                                            ((it
+                                              (Exp_var
+                                               ((it eval_bin_op)
+                                                (range
+                                                 ((start 761) (stop 772)
+                                                  (source
+                                                   (Reader
+                                                    ((id 0)
+                                                     (name (expect_test.ml))
+                                                     (length 806)
+                                                     (unsafe_get <fun>)))))))))
                                              (range
                                               ((start 761) (stop 772)
                                                (source
                                                 (Reader
                                                  ((id 0) (name (expect_test.ml))
                                                   (length 806)
-                                                  (unsafe_get <fun>)))))))))
-                                          (range
-                                           ((start 761) (stop 772)
-                                            (source
-                                             (Reader
-                                              ((id 0) (name (expect_test.ml))
-                                               (length 806) (unsafe_get <fun>)))))))
-                                         ((it
-                                           (Exp_var
-                                            ((it op)
+                                                  (unsafe_get <fun>)))))))
+                                            ((it
+                                              (Exp_var
+                                               ((it op)
+                                                (range
+                                                 ((start 773) (stop 775)
+                                                  (source
+                                                   (Reader
+                                                    ((id 0)
+                                                     (name (expect_test.ml))
+                                                     (length 806)
+                                                     (unsafe_get <fun>)))))))))
                                              (range
                                               ((start 773) (stop 775)
                                                (source
@@ -4270,20 +4394,21 @@ let%expect_test "eval example" =
                                                   (length 806)
                                                   (unsafe_get <fun>)))))))))
                                           (range
-                                           ((start 773) (stop 775)
+                                           ((start 761) (stop 775)
                                             (source
                                              (Reader
                                               ((id 0) (name (expect_test.ml))
-                                               (length 806) (unsafe_get <fun>)))))))))
-                                       (range
-                                        ((start 761) (stop 775)
-                                         (source
-                                          (Reader
-                                           ((id 0) (name (expect_test.ml))
-                                            (length 806) (unsafe_get <fun>)))))))
-                                      ((it
-                                        (Exp_var
-                                         ((it n1)
+                                               (length 806) (unsafe_get <fun>)))))))
+                                         ((it
+                                           (Exp_var
+                                            ((it n1)
+                                             (range
+                                              ((start 776) (stop 778)
+                                               (source
+                                                (Reader
+                                                 ((id 0) (name (expect_test.ml))
+                                                  (length 806)
+                                                  (unsafe_get <fun>)))))))))
                                           (range
                                            ((start 776) (stop 778)
                                             (source
@@ -4291,20 +4416,20 @@ let%expect_test "eval example" =
                                               ((id 0) (name (expect_test.ml))
                                                (length 806) (unsafe_get <fun>)))))))))
                                        (range
-                                        ((start 776) (stop 778)
+                                        ((start 761) (stop 778)
                                          (source
                                           (Reader
                                            ((id 0) (name (expect_test.ml))
-                                            (length 806) (unsafe_get <fun>)))))))))
-                                    (range
-                                     ((start 761) (stop 778)
-                                      (source
-                                       (Reader
-                                        ((id 0) (name (expect_test.ml))
-                                         (length 806) (unsafe_get <fun>)))))))
-                                   ((it
-                                     (Exp_var
-                                      ((it n2)
+                                            (length 806) (unsafe_get <fun>)))))))
+                                      ((it
+                                        (Exp_var
+                                         ((it n2)
+                                          (range
+                                           ((start 779) (stop 781)
+                                            (source
+                                             (Reader
+                                              ((id 0) (name (expect_test.ml))
+                                               (length 806) (unsafe_get <fun>)))))))))
                                        (range
                                         ((start 779) (stop 781)
                                          (source
@@ -4312,43 +4437,43 @@ let%expect_test "eval example" =
                                            ((id 0) (name (expect_test.ml))
                                             (length 806) (unsafe_get <fun>)))))))))
                                     (range
-                                     ((start 779) (stop 781)
+                                     ((start 761) (stop 781)
                                       (source
                                        (Reader
                                         ((id 0) (name (expect_test.ml))
                                          (length 806) (unsafe_get <fun>)))))))))
                                  (range
-                                  ((start 761) (stop 781)
+                                  ((start 724) (stop 781)
                                    (source
                                     (Reader
                                      ((id 0) (name (expect_test.ml)) (length 806)
                                       (unsafe_get <fun>)))))))))
                               (range
-                               ((start 724) (stop 781)
+                               ((start 688) (stop 781)
                                 (source
                                  (Reader
                                   ((id 0) (name (expect_test.ml)) (length 806)
-                                   (unsafe_get <fun>)))))))))
-                           (range
-                            ((start 688) (stop 781)
-                             (source
-                              (Reader
-                               ((id 0) (name (expect_test.ml)) (length 806)
-                                (unsafe_get <fun>))))))))))
-                       (range
-                        ((start 650) (stop 781)
-                         (source
-                          (Reader
-                           ((id 0) (name (expect_test.ml)) (length 806)
-                            (unsafe_get <fun>))))))))))
+                                   (unsafe_get <fun>))))))))))
+                          (range
+                           ((start 650) (stop 781)
+                            (source
+                             (Reader
+                              ((id 0) (name (expect_test.ml)) (length 806)
+                               (unsafe_get <fun>))))))))))
+                      (range
+                       ((start 378) (stop 791)
+                        (source
+                         (Reader
+                          ((id 0) (name (expect_test.ml)) (length 806)
+                           (unsafe_get <fun>)))))))))
                    (range
-                    ((start 378) (stop 791)
+                    ((start 350) (stop 791)
                      (source
                       (Reader
                        ((id 0) (name (expect_test.ml)) (length 806)
                         (unsafe_get <fun>)))))))))
                 (range
-                 ((start 350) (stop 791)
+                 ((start 345) (stop 799)
                   (source
                    (Reader
                     ((id 0) (name (expect_test.ml)) (length 806)

--- a/lib/parser/token.mly
+++ b/lib/parser/token.mly
@@ -21,6 +21,7 @@
 
 // operators
 %token RIGHT_ARROW "->"
+%token QUESTION_MARK "?"
 %token COLON ":"
 %token EQUAL "="
 %token DOT "."

--- a/lib/parser/token.mly
+++ b/lib/parser/token.mly
@@ -17,6 +17,7 @@
 %token AS "as"
 %token OF "of"
 %token EXTERNAL "external"
+%token IMPLICIT "implicit"
 %token SEMI_SEMI_COLON ";;"
 
 // operators

--- a/lib/type_checker/env.ml
+++ b/lib/type_checker/env.ml
@@ -2,6 +2,21 @@ open! Import
 open Ast_types
 open Adt
 
+module Var_binding = struct
+  type t =
+    { var : Constraint.Var.t option
+    ; overloads : Constraint.Var.t Over_name.Map.t
+    }
+  [@@deriving sexp_of]
+
+  let empty = { var = None; overloads = Over_name.Map.empty }
+  let set t var = { t with var = Some var }
+
+  let set_overload t over_name cvar =
+    { t with overloads = Map.set t.overloads ~key:over_name ~data:cvar }
+  ;;
+end
+
 type t =
   { id_source : Identifier.source
     (** [id_source] is the identifier source for any constraint variables
@@ -16,7 +31,7 @@ type t =
   ; type_vars : Type.Var.t Type_var_name.Map.t
     (** [type_vars] is a renaming from (user-defined) type variables to
       constraint type variables (unique). *)
-  ; vars : Constraint.Var.t Var_name.Map.t
+  ; vars : Var_binding.t Var_name.Map.t
     (** [vars] is a renaming from (user-defined) variable names to
       constraint variables (unique). *)
   }
@@ -93,10 +108,33 @@ let rename_type_var t ~type_var ~in_ =
   in_ t ctype_var
 ;;
 
-let rename_var t ~var ~in_ =
-  let cvar =
-    Constraint.Var.create ~id_source:t.id_source ~name:(var : Var_name.t :> string) ()
+let rename_var_binding ~name ~set_binding t ~var ~in_ =
+  let cvar = Constraint.Var.create ~id_source:t.id_source ~name () in
+  let t =
+    { t with
+      vars =
+        Map.update t.vars var ~f:(fun binding ->
+          let binding = Option.value binding ~default:Var_binding.empty in
+          set_binding binding cvar)
+    }
   in
-  let t = { t with vars = Map.set t.vars ~key:var ~data:cvar } in
   in_ t cvar
+;;
+
+let rename_var t ~var ~in_ =
+  rename_var_binding
+    ~name:(var : Var_name.t :> string)
+    ~set_binding:Var_binding.set
+    t
+    ~var
+    ~in_
+;;
+
+let rename_over_path t ~over_path:(over_name, var) ~in_ =
+  rename_var_binding
+    ~name:(Fmt.str "%a?%a" Over_name.pp over_name Var_name.pp var)
+    ~set_binding:(fun binding cvar -> Var_binding.set_overload binding over_name cvar)
+    t
+    ~var
+    ~in_
 ;;

--- a/lib/type_checker/env.ml
+++ b/lib/type_checker/env.ml
@@ -4,17 +4,10 @@ open Adt
 
 module Var_binding = struct
   type t =
-    { var : Constraint.Var.t option
-    ; overloads : Constraint.Var.t Over_name.Map.t
+    { var : Constraint.Var.t
+    ; implicit_arity : int
     }
   [@@deriving sexp_of]
-
-  let empty = { var = None; overloads = Over_name.Map.empty }
-  let set t var = { t with var = Some var }
-
-  let set_overload t over_name cvar =
-    { t with overloads = Map.set t.overloads ~key:over_name ~data:cvar }
-  ;;
 end
 
 type t =
@@ -33,7 +26,9 @@ type t =
       constraint type variables (unique). *)
   ; vars : Var_binding.t Var_name.Map.t
     (** [vars] is a renaming from (user-defined) variable names to
-      constraint variables (unique). *)
+        constraint variables (unique). *)
+  ; implicit_scope : Constraint.Implicit_scope.t
+    (** [implicit_scope] is a set of variables in the implicit scope. *)
   }
 
 let empty ?(id_source = Identifier.create_source ()) () =
@@ -43,10 +38,17 @@ let empty ?(id_source = Identifier.create_source ()) () =
   ; type_vars = Type_var_name.Map.empty
   ; types = Type_name.Map.empty
   ; vars = Var_name.Map.empty
+  ; implicit_scope = Constraint.Implicit_scope.{ vars = Constraint.Var.Set.empty }
   }
 ;;
 
 let id_source t = t.id_source [@@inline]
+
+let add_implicit_var t var =
+  { t with implicit_scope = { vars = Set.add t.implicit_scope.vars var } }
+;;
+
+let implicit_scope t = t.implicit_scope
 
 let add_constr_def t (constr_def : constructor_definition) =
   { t with
@@ -108,33 +110,11 @@ let rename_type_var t ~type_var ~in_ =
   in_ t ctype_var
 ;;
 
-let rename_var_binding ~name ~set_binding t ~var ~in_ =
-  let cvar = Constraint.Var.create ~id_source:t.id_source ~name () in
-  let t =
-    { t with
-      vars =
-        Map.update t.vars var ~f:(fun binding ->
-          let binding = Option.value binding ~default:Var_binding.empty in
-          set_binding binding cvar)
-    }
+let rename_var t ~var ~implicit_arity ~in_ =
+  let cvar =
+    Constraint.Var.create ~id_source:t.id_source ~name:(var : Var_name.t :> string) ()
   in
+  let var_binding = Var_binding.{ var = cvar; implicit_arity } in
+  let t = { t with vars = Map.set t.vars ~key:var ~data:var_binding } in
   in_ t cvar
-;;
-
-let rename_var t ~var ~in_ =
-  rename_var_binding
-    ~name:(var : Var_name.t :> string)
-    ~set_binding:Var_binding.set
-    t
-    ~var
-    ~in_
-;;
-
-let rename_over_path t ~over_path:(over_name, var) ~in_ =
-  rename_var_binding
-    ~name:(Fmt.str "%a?%a" Over_name.pp over_name Var_name.pp var)
-    ~set_binding:(fun binding cvar -> Var_binding.set_overload binding over_name cvar)
-    t
-    ~var
-    ~in_
 ;;

--- a/lib/type_checker/env.mli
+++ b/lib/type_checker/env.mli
@@ -46,11 +46,27 @@ val find_label : t -> Label_name.t -> label_definition list
     empty list is returned. *)
 val find_type_def : t -> Type_name.t -> type_definition list
 
+module Var_binding : sig
+  type t =
+    { var : Constraint.Var.t option
+    ; overloads : Constraint.Var.t Over_name.Map.t
+    }
+  [@@deriving sexp_of]
+end
+
 (** [find_var t var_name] returns the constraint variable that [var_name] is renamed to. *)
-val find_var : t -> Var_name.t -> Constraint.Var.t option
+val find_var : t -> Var_name.t -> Var_binding.t option
 
 (** [rename_var t ~var ~in_] renames the variable [var] to some fresh [cvar] in [in_]. *)
 val rename_var : t -> var:Var_name.t -> in_:(t -> Constraint.Var.t -> 'a) -> 'a
+
+(** [rename_over_path t ~over_path ~in_] renames the qualified variable [over_path] to some 
+    fresh [cvar] in [in_]. *)
+val rename_over_path
+  :  t
+  -> over_path:Over_name.t * Var_name.t
+  -> in_:(t -> Constraint.Var.t -> 'a)
+  -> 'a
 
 (** [find_type_var t type_var_name] returns the type variable that [type_var_name]
     is renamed to. *)

--- a/lib/type_checker/env.mli
+++ b/lib/type_checker/env.mli
@@ -48,8 +48,8 @@ val find_type_def : t -> Type_name.t -> type_definition list
 
 module Var_binding : sig
   type t =
-    { var : Constraint.Var.t option
-    ; overloads : Constraint.Var.t Over_name.Map.t
+    { var : Constraint.Var.t
+    ; implicit_arity : int
     }
   [@@deriving sexp_of]
 end
@@ -58,13 +58,10 @@ end
 val find_var : t -> Var_name.t -> Var_binding.t option
 
 (** [rename_var t ~var ~in_] renames the variable [var] to some fresh [cvar] in [in_]. *)
-val rename_var : t -> var:Var_name.t -> in_:(t -> Constraint.Var.t -> 'a) -> 'a
-
-(** [rename_over_path t ~over_path ~in_] renames the qualified variable [over_path] to some 
-    fresh [cvar] in [in_]. *)
-val rename_over_path
+val rename_var
   :  t
-  -> over_path:Over_name.t * Var_name.t
+  -> var:Var_name.t
+  -> implicit_arity:int
   -> in_:(t -> Constraint.Var.t -> 'a)
   -> 'a
 
@@ -75,3 +72,6 @@ val find_type_var : t -> Type_var_name.t -> Type.Var.t option
 (** [rename_type_var t ~type_var ~in_] renames the type variable [type_var] to some fresh
     [ctype_var] in [in_]. *)
 val rename_type_var : t -> type_var:Type_var_name.t -> in_:(t -> Type.Var.t -> 'a) -> 'a
+
+val add_implicit_var : t -> Constraint.Var.t -> t
+val implicit_scope : t -> Constraint.Implicit_scope.t

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -715,12 +715,13 @@ module Expression = struct
     let_
       (poly_binding
          (((Flexible, pat_type) :: pat_quantifiers)
-          @. (match_inst
-                ~id_source
-                ~range:pat.range
-                ~poly_type:param_type
-                ~mono_type:pat_type
-              &~ cpat)
+          @. []
+          @?-> (match_inst
+                  ~id_source
+                  ~range:pat.range
+                  ~poly_type:param_type
+                  ~mono_type:pat_type
+                &~ cpat)
           @=> bindings))
       ~in_:(in_ env)
   ;;
@@ -742,7 +743,8 @@ module Expression = struct
     &~ let_
          (poly_binding
             ((scheme_quantifiers @ pat_quantifiers)
-             @. (cpat &~ Type.(var pat_type =~ scheme.body))
+             @. []
+             @?-> (cpat &~ Type.(var pat_type =~ scheme.body))
              @=> bindings))
          ~in_:(in_ env)
   ;;
@@ -856,7 +858,8 @@ module Expression = struct
       let_
         (poly_binding
            (((Flexible, exp_type') :: rigid_type_vars)
-            @. c
+            @. []
+            @?-> c
             @=> [ x @: Type.var exp_type' ]))
         ~in_:(inst x (Type.var exp_type))
     | Exp_annot (exp, annot) ->
@@ -988,6 +991,10 @@ module Expression = struct
       @@ fun poly_type ->
       infer_exp ~env ~with_poly_params exp poly_type
       &~ match_inst ~id_source ~range:exp.range ~poly_type ~mono_type:exp_type
+    | Exp_let_implicit (var_name, exp) ->
+      infer_implicit_binding ~env var_name
+      @@ fun () -> infer_exp ~env ~with_poly_params exp exp_type
+    | Exp_implicit -> implicit Type.(var exp_type)
 
   and infer_exps ~env ~with_poly_params exps k =
     match exps with
@@ -1016,7 +1023,8 @@ module Expression = struct
     let_
       (poly_binding
          ([ Flexible, exp_type ]
-          @. infer_exp ~env ~with_poly_params exp exp_type
+          @. []
+          @?-> infer_exp ~env ~with_poly_params exp exp_type
           @=> [ cvar @: Type.var exp_type ]))
       ~in_:(k cvar)
 
@@ -1031,20 +1039,52 @@ module Expression = struct
     bind_mono_pat ~env ~with_poly_params pat lhs_type ~in_:(fun env ->
       infer_exp ~env ~with_poly_params exp rhs_type)
 
+  and infer_term ~env ~with_poly_params (term : term) exp_type =
+    match term.it with
+    | Term_exp exp -> [], [], infer_exp ~env ~with_poly_params exp exp_type
+    | Term_implicit_fun (pats, exp) ->
+      let pat_and_types =
+        List.map pats ~f:(fun pat ->
+          pat, Type.Var.create ~id_source:(Env.id_source env) ())
+      in
+      let rec bind_pats ~env pat_and_types ~in_ =
+        match pat_and_types with
+        | [] -> in_ env
+        | (pat, pat_type) :: pat_and_types ->
+          bind_mono_pat ~env ~with_poly_params pat pat_type ~in_:(fun env ->
+            bind_pats ~env pat_and_types ~in_)
+      in
+      let cexp =
+        bind_pats ~env pat_and_types ~in_:(fun env ->
+          infer_exp ~env ~with_poly_params exp exp_type)
+      in
+      let implicit_vars = List.map pat_and_types ~f:snd in
+      implicit_vars, List.map implicit_vars ~f:Type.var, cexp
+
   and infer_value_binding ~(env : Env.t) ~with_poly_params value_binding k =
-    let { value_binding_pat = pat; value_binding_exp = exp } = value_binding.it in
+    let { value_binding_pat = pat; value_binding_term = term } = value_binding.it in
     let exp_type = Type.Var.create ~id_source:(Env.id_source env) () in
-    let cexp = infer_exp ~env ~with_poly_params exp exp_type in
+    let implicit_bindings, implicits, cexp =
+      infer_term ~env ~with_poly_params term exp_type
+    in
     let env, bindings, exists_bindings, cpat =
       infer_pat ~env ~with_poly_params pat exp_type
     in
     let cin = k env in
     let_
       (poly_binding
-         (((Flexible, exp_type) :: List.map exists_bindings ~f:(fun v -> Flexible, v))
-          @. (cexp &~ cpat)
+         (((Flexible, exp_type)
+           :: List.map (exists_bindings @ implicit_bindings) ~f:(fun v -> Flexible, v))
+          @. implicits
+          @?-> (cexp &~ cpat)
           @=> bindings))
       ~in_:cin
+
+  and infer_implicit_binding ~(env : Env.t) var_name k =
+    let binding = find_var_binding ~env var_name in
+    match binding.var with
+    | None -> Omniml_error.(raise @@ unbound_variable ~range:var_name.range var_name.it)
+    | Some var -> let_implicit var ~in_:(k ())
   ;;
 end
 
@@ -1055,7 +1095,7 @@ module Structure = struct
     let quantifiers = List.map ~f:(fun q -> Flexible, q) quantifiers in
     Env.rename_var env ~var:value_name.it ~in_:(fun env cvar ->
       let c = k env in
-      let_ (poly_binding (quantifiers @. tt @=> [ cvar @: type_ ])) ~in_:c)
+      let_ (poly_binding (quantifiers @. [] @?-> tt @=> [ cvar @: type_ ])) ~in_:c)
   ;;
 
   let infer_type_decl
@@ -1159,5 +1199,9 @@ module Structure = struct
       with_range ~range
       @@ Expression.infer_value_binding ~env ~with_poly_params value_binding
       @@ fun env -> infer_str ~env ~with_poly_params str
+    | { it = Str_implicit var_name; range } :: str ->
+      with_range ~range
+      @@ Expression.infer_implicit_binding ~env var_name
+      @@ fun () -> infer_str ~env ~with_poly_params str
   ;;
 end

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -427,27 +427,55 @@ let inst_label ~(env : Env.t) ~(label_name : Label_name.With_range.t) ~label_typ
 
 module Pattern = struct
   module Fragment = struct
+    module Var_binding = struct
+      type t =
+        { var : Type.Var.t option
+        ; overloads : Type.Var.t Over_name.Map.t
+        }
+      [@@deriving sexp_of]
+
+      let empty = { var = None; overloads = Over_name.Map.empty }
+      let set t var = { t with var = Some var }
+
+      let set_overload t over_name var =
+        { t with overloads = Map.set t.overloads ~key:over_name ~data:var }
+      ;;
+
+      let merge t1 t2 =
+        { var = Option.merge t1.var t2.var ~f:(fun _ x -> x)
+        ; overloads =
+            Map.merge_skewed t1.overloads t2.overloads ~combine:(fun ~key:_ _ x -> x)
+        }
+      ;;
+    end
+
     type t =
-      { var_bindings : Type.Var.t Var_name.Map.t
+      { var_bindings : Var_binding.t Var_name.Map.t
       ; exist_bindings : Type.Var.t list
       }
     [@@deriving sexp_of]
 
     let empty = { var_bindings = Var_name.Map.empty; exist_bindings = [] }
 
-    let singleton var type_ =
-      { var_bindings = Var_name.Map.singleton var type_; exist_bindings = [] }
+    let singleton var binding =
+      { var_bindings = Var_name.Map.singleton var binding; exist_bindings = [] }
     ;;
 
-    let extend t ~var ~type_ =
-      { t with var_bindings = Map.set t.var_bindings ~key:var ~data:type_ }
+    let extend t ~var ~f =
+      { t with
+        var_bindings =
+          Map.update t.var_bindings var ~f:(fun binding ->
+            let binding = Option.value binding ~default:Var_binding.empty in
+            f binding)
+      }
     ;;
 
     let exists t type_var = { t with exist_bindings = type_var :: t.exist_bindings }
 
     let merge t1 t2 =
       { var_bindings =
-          Map.merge_skewed t1.var_bindings t2.var_bindings ~combine:(fun ~key:_ _ b -> b)
+          Map.merge_skewed t1.var_bindings t2.var_bindings ~combine:(fun ~key:_ b1 b2 ->
+            Var_binding.merge b1 b2)
       ; exist_bindings = t1.exist_bindings @ t2.exist_bindings
       }
     ;;
@@ -472,10 +500,7 @@ module Pattern = struct
     include Monad.Make (T)
 
     let perform_exists type_var = fun fragment -> Fragment.exists fragment type_var, ()
-
-    let perform_extend ~var ~type_ =
-      fun fragment -> Fragment.extend fragment ~var ~type_, ()
-    ;;
+    let perform_extend ~var ~f = fun fragment -> Fragment.extend fragment ~var ~f, ()
 
     let exists ~id_source f =
       let open Let_syntax in
@@ -515,11 +540,23 @@ module Pattern = struct
     match pat.it with
     | Pat_any -> return tt
     | Pat_var x ->
-      let%map () = perform_extend ~var:x.it ~type_:pat_type in
+      let%map () =
+        perform_extend ~var:x.it ~f:(fun binding ->
+          Fragment.Var_binding.set binding pat_type)
+      in
+      tt
+    | Pat_over over_path ->
+      let%map () =
+        perform_extend ~var:over_path.it.var.it ~f:(fun binding ->
+          Fragment.Var_binding.set_overload binding over_path.it.qualifier.it pat_type)
+      in
       tt
     | Pat_alias (pat, x) ->
       let%bind cpat = infer_pat ~env ~with_poly_params pat pat_type in
-      let%map () = perform_extend ~var:x.it ~type_:pat_type in
+      let%map () =
+        perform_extend ~var:x.it ~f:(fun binding ->
+          Fragment.Var_binding.set binding pat_type)
+      in
       cpat
     | Pat_const const -> return @@ Type.(var pat_type =~ infer_constant const)
     | Pat_tuple pats ->
@@ -634,10 +671,22 @@ module Expression = struct
     let env, bindings =
       var_bindings
       |> Map.to_alist
-      |> List.fold_map ~init:env ~f:(fun env (var, type_) ->
-        Env.rename_var env ~var ~in_:(fun env cvar -> env, cvar @: Type.var type_))
+      |> List.fold_map ~init:env ~f:(fun env (var, binding) ->
+        let in_ env =
+          binding.overloads
+          |> Map.to_alist
+          |> List.fold_map ~init:env ~f:(fun env (over_name, type_) ->
+            Env.rename_over_path env ~over_path:(over_name, var) ~in_:(fun env cvar ->
+              env, cvar @: Type.var type_))
+        in
+        match binding.var with
+        | None -> in_ env
+        | Some type_ ->
+          Env.rename_var env ~var ~in_:(fun env cvar ->
+            let env, bindings = in_ env in
+            env, (cvar @: Type.var type_) :: bindings))
     in
-    env, bindings, exist_bindings, cpat
+    env, List.concat bindings, exist_bindings, cpat
   ;;
 
   let bind_mono_pat ~env ~with_poly_params (pat : pattern) pat_type ~in_ =
@@ -716,6 +765,12 @@ module Expression = struct
         bind_params ~env ~with_poly_params params_and_types ~in_)
   ;;
 
+  let find_var_binding ~env (var : Var_name.With_range.t) =
+    match Env.find_var env var.it with
+    | Some binding -> binding
+    | None -> Omniml_error.(raise @@ unbound_variable ~range:var.range var.it)
+  ;;
+
   let rec infer_exp
             ~(env : Env.t)
             ~with_poly_params
@@ -727,9 +782,27 @@ module Expression = struct
     @@
     match exp.it with
     | Exp_var var ->
-      (match Env.find_var env var.it with
-       | Some var -> inst var (Type.var exp_type)
-       | None -> Omniml_error.(raise @@ unbound_variable ~range:var.range var.it))
+      let binding = find_var_binding ~env var in
+      (match binding.var with
+       | Some var -> inst var Type.(var exp_type)
+       | None ->
+         (if Map.is_empty binding.overloads
+          then
+            Omniml_error.(
+              raise
+              @@ bug_s
+                   ~here:[%here]
+                   [%message
+                     "Overloads is empty"
+                       (var : Var_name.With_range.t)
+                       (binding : Env.Var_binding.t)]));
+         let vars = Map.data binding.overloads in
+         over vars Type.(var exp_type))
+    | Exp_over over_path ->
+      let binding = find_var_binding ~env over_path.it.var in
+      (match Map.find binding.overloads over_path.it.qualifier.it with
+       | Some var -> inst var Type.(var exp_type)
+       | None -> Omniml_error.(raise @@ unbound_over_path over_path))
     | Exp_const const -> Type.(var exp_type =~ infer_constant const)
     | Exp_fun (params, exp) ->
       exists_many' ~id_source (List.length params)

--- a/lib/type_checker/infer.ml
+++ b/lib/type_checker/infer.ml
@@ -333,12 +333,13 @@ struct
         ret
         ~closure:(X.arg_closure arg |> List.map ~f:(fun v -> `Type v))
         ~with_:(function
-          | (Arrow (_, _) | Tuple _ | Poly _) as matchee ->
+          | (Arrow (_, _) | Tuple _ | Implicit_arrow _ | Poly _) as matchee ->
             let type_head =
               match matchee with
               | Arrow (_, _) -> `Arrow
               | Tuple _ -> `Tuple
               | Poly _ -> `Poly
+              | Implicit_arrow _ -> `Implicit_arrow
               | _ -> assert false
             in
             ff (Omniml_error.disambiguation_mismatched_type ~range:name.range ~type_head)
@@ -427,30 +428,8 @@ let inst_label ~(env : Env.t) ~(label_name : Label_name.With_range.t) ~label_typ
 
 module Pattern = struct
   module Fragment = struct
-    module Var_binding = struct
-      type t =
-        { var : Type.Var.t option
-        ; overloads : Type.Var.t Over_name.Map.t
-        }
-      [@@deriving sexp_of]
-
-      let empty = { var = None; overloads = Over_name.Map.empty }
-      let set t var = { t with var = Some var }
-
-      let set_overload t over_name var =
-        { t with overloads = Map.set t.overloads ~key:over_name ~data:var }
-      ;;
-
-      let merge t1 t2 =
-        { var = Option.merge t1.var t2.var ~f:(fun _ x -> x)
-        ; overloads =
-            Map.merge_skewed t1.overloads t2.overloads ~combine:(fun ~key:_ _ x -> x)
-        }
-      ;;
-    end
-
     type t =
-      { var_bindings : Var_binding.t Var_name.Map.t
+      { var_bindings : Type.Var.t Var_name.Map.t
       ; exist_bindings : Type.Var.t list
       }
     [@@deriving sexp_of]
@@ -461,21 +440,16 @@ module Pattern = struct
       { var_bindings = Var_name.Map.singleton var binding; exist_bindings = [] }
     ;;
 
-    let extend t ~var ~f =
-      { t with
-        var_bindings =
-          Map.update t.var_bindings var ~f:(fun binding ->
-            let binding = Option.value binding ~default:Var_binding.empty in
-            f binding)
-      }
+    let extend t ~var ~type_ =
+      { t with var_bindings = Map.set t.var_bindings ~key:var ~data:type_ }
     ;;
 
     let exists t type_var = { t with exist_bindings = type_var :: t.exist_bindings }
 
     let merge t1 t2 =
       { var_bindings =
-          Map.merge_skewed t1.var_bindings t2.var_bindings ~combine:(fun ~key:_ b1 b2 ->
-            Var_binding.merge b1 b2)
+          Map.merge_skewed t1.var_bindings t2.var_bindings ~combine:(fun ~key:_ _b1 b2 ->
+            b2)
       ; exist_bindings = t1.exist_bindings @ t2.exist_bindings
       }
     ;;
@@ -500,7 +474,10 @@ module Pattern = struct
     include Monad.Make (T)
 
     let perform_exists type_var = fun fragment -> Fragment.exists fragment type_var, ()
-    let perform_extend ~var ~f = fun fragment -> Fragment.extend fragment ~var ~f, ()
+
+    let perform_extend ~var ~type_ =
+      fun fragment -> Fragment.extend fragment ~var ~type_, ()
+    ;;
 
     let exists ~id_source f =
       let open Let_syntax in
@@ -540,23 +517,12 @@ module Pattern = struct
     match pat.it with
     | Pat_any -> return tt
     | Pat_var x ->
-      let%map () =
-        perform_extend ~var:x.it ~f:(fun binding ->
-          Fragment.Var_binding.set binding pat_type)
-      in
+      let%map () = perform_extend ~var:x.it ~type_:pat_type in
       tt
-    | Pat_over over_path ->
-      let%map () =
-        perform_extend ~var:over_path.it.var.it ~f:(fun binding ->
-          Fragment.Var_binding.set_overload binding over_path.it.qualifier.it pat_type)
-      in
-      tt
+    | Pat_over _over_path -> assert false
     | Pat_alias (pat, x) ->
       let%bind cpat = infer_pat ~env ~with_poly_params pat pat_type in
-      let%map () =
-        perform_extend ~var:x.it ~f:(fun binding ->
-          Fragment.Var_binding.set binding pat_type)
-      in
+      let%map () = perform_extend ~var:x.it ~type_:pat_type in
       cpat
     | Pat_const const -> return @@ Type.(var pat_type =~ infer_constant const)
     | Pat_tuple pats ->
@@ -651,7 +617,7 @@ module Expression = struct
       ~with_:(function
         | Poly { quantifiers; body } ->
           exists_many quantifiers Type.(var mono_type =~ body)
-        | (Arrow _ | Constr _ | Tuple _) as matchee ->
+        | (Arrow _ | Constr _ | Tuple _ | Implicit_arrow _) as matchee ->
           let type_head =
             match matchee with
             | Arrow _ -> `Arrow
@@ -664,34 +630,24 @@ module Expression = struct
       ~else_:(fun () -> default_mono_poly ~id_source)
   ;;
 
-  let infer_pat ~env ~with_poly_params pat pat_type =
+  let infer_pat ~env ~with_poly_params ~implicits pat pat_type =
     let { Pattern.Fragment.var_bindings; exist_bindings }, cpat =
       Pattern.(infer_pat ~env ~with_poly_params pat pat_type |> With_fragment.run)
     in
+    let implicit_arity = List.length implicits in
     let env, bindings =
       var_bindings
       |> Map.to_alist
-      |> List.fold_map ~init:env ~f:(fun env (var, binding) ->
-        let in_ env =
-          binding.overloads
-          |> Map.to_alist
-          |> List.fold_map ~init:env ~f:(fun env (over_name, type_) ->
-            Env.rename_over_path env ~over_path:(over_name, var) ~in_:(fun env cvar ->
-              env, cvar @: Type.var type_))
-        in
-        match binding.var with
-        | None -> in_ env
-        | Some type_ ->
-          Env.rename_var env ~var ~in_:(fun env cvar ->
-            let env, bindings = in_ env in
-            env, (cvar @: Type.var type_) :: bindings))
+      |> List.fold_map ~init:env ~f:(fun env (var, type_) ->
+        Env.rename_var env ~var ~implicit_arity ~in_:(fun env cvar ->
+          env, cvar @: List.fold_right implicits ~init:(Type.var type_) ~f:Type.( @=> )))
     in
-    env, List.concat bindings, exist_bindings, cpat
+    env, bindings, exist_bindings, cpat
   ;;
 
   let bind_mono_pat ~env ~with_poly_params (pat : pattern) pat_type ~in_ =
     let env, bindings, exists_bindings, cpat =
-      infer_pat ~env ~with_poly_params pat pat_type
+      infer_pat ~env ~with_poly_params ~implicits:[] pat pat_type
     in
     let in_ = in_ env in
     exists_many exists_bindings (cpat &~ let_ (mono_binding bindings) ~in_)
@@ -709,19 +665,18 @@ module Expression = struct
     let id_source = Env.id_source env in
     let pat_type = Type.Var.create ~id_source () in
     let env, bindings, exist_bindings, cpat =
-      infer_pat ~env ~with_poly_params pat pat_type
+      infer_pat ~env ~with_poly_params ~implicits:[] pat pat_type
     in
     let pat_quantifiers = List.map exist_bindings ~f:(fun v -> Flexible, v) in
     let_
       (poly_binding
          (((Flexible, pat_type) :: pat_quantifiers)
-          @. []
-          @?-> (match_inst
-                  ~id_source
-                  ~range:pat.range
-                  ~poly_type:param_type
-                  ~mono_type:pat_type
-                &~ cpat)
+          @. (match_inst
+                ~id_source
+                ~range:pat.range
+                ~poly_type:param_type
+                ~mono_type:pat_type
+              &~ cpat)
           @=> bindings))
       ~in_:(in_ env)
   ;;
@@ -733,7 +688,7 @@ module Expression = struct
     (* Infer the pattern *)
     let pat_type = Type.Var.create ~id_source () in
     let env, bindings, exist_bindings, cpat =
-      infer_pat ~env ~with_poly_params pat pat_type
+      infer_pat ~env ~with_poly_params ~implicits:[] pat pat_type
     in
     let pat_quantifiers =
       (Flexible, pat_type) :: List.map exist_bindings ~f:(fun v -> Flexible, v)
@@ -743,8 +698,7 @@ module Expression = struct
     &~ let_
          (poly_binding
             ((scheme_quantifiers @ pat_quantifiers)
-             @. []
-             @?-> (cpat &~ Type.(var pat_type =~ scheme.body))
+             @. (cpat &~ Type.(var pat_type =~ scheme.body))
              @=> bindings))
          ~in_:(in_ env)
   ;;
@@ -785,26 +739,20 @@ module Expression = struct
     match exp.it with
     | Exp_var var ->
       let binding = find_var_binding ~env var in
-      (match binding.var with
-       | Some var -> inst var Type.(var exp_type)
-       | None ->
-         (if Map.is_empty binding.overloads
-          then
-            Omniml_error.(
-              raise
-              @@ bug_s
-                   ~here:[%here]
-                   [%message
-                     "Overloads is empty"
-                       (var : Var_name.With_range.t)
-                       (binding : Env.Var_binding.t)]));
-         let vars = Map.data binding.overloads in
-         over vars Type.(var exp_type))
-    | Exp_over over_path ->
-      let binding = find_var_binding ~env over_path.it.var in
-      (match Map.find binding.overloads over_path.it.qualifier.it with
-       | Some var -> inst var Type.(var exp_type)
-       | None -> Omniml_error.(raise @@ unbound_over_path over_path))
+      let implicit_vars =
+        List.init binding.implicit_arity ~f:(fun _ -> Type.Var.create ~id_source ())
+      in
+      let implicit_arr_type =
+        List.fold_right implicit_vars ~init:(Type.var exp_type) ~f:(fun iv arr ->
+          Type.(var iv @=> arr))
+      in
+      let implicit_scope = Env.implicit_scope env in
+      exists_many implicit_vars
+      @@ (inst binding.var implicit_arr_type
+          &~ all
+               (List.map implicit_vars ~f:(fun iv ->
+                  implicit (Type.var iv) ~in_:implicit_scope)))
+    | Exp_over _over_path -> assert false
     | Exp_const const -> Type.(var exp_type =~ infer_constant const)
     | Exp_fun (params, exp) ->
       exists_many' ~id_source (List.length params)
@@ -858,8 +806,7 @@ module Expression = struct
       let_
         (poly_binding
            (((Flexible, exp_type') :: rigid_type_vars)
-            @. []
-            @?-> c
+            @. c
             @=> [ x @: Type.var exp_type' ]))
         ~in_:(inst x (Type.var exp_type))
     | Exp_annot (exp, annot) ->
@@ -886,10 +833,11 @@ module Expression = struct
                   ff
                     (Omniml_error.projection_out_of_bounds ~range:exp.range ~index ~arity)
                 | Some comp_type -> Type.(var exp_type =~ var comp_type))
-             | (Arrow _ | Constr _ | Poly _) as matchee ->
+             | (Arrow _ | Implicit_arrow _ | Constr _ | Poly _) as matchee ->
                let type_head =
                  match matchee with
                  | Arrow _ -> `Arrow
+                 | Implicit_arrow _ -> `Implicit_arrow
                  | Constr _ -> `Constr
                  | Poly _ -> `Poly
                  | _ -> assert false
@@ -964,10 +912,11 @@ module Expression = struct
            ~closure:[ `Scheme cvar ]
            ~with_:(function
              | Poly { quantifiers; body } -> forall quantifiers @@ inst cvar body
-             | (Arrow _ | Constr _ | Tuple _) as matchee ->
+             | (Arrow _ | Implicit_arrow _ | Constr _ | Tuple _) as matchee ->
                let type_head =
                  match matchee with
                  | Arrow _ -> `Arrow
+                 | Implicit_arrow _ -> `Implicit_arrow
                  | Constr _ -> `Constr
                  | Tuple _ -> `Tuple
                  | _ -> assert false
@@ -993,8 +942,8 @@ module Expression = struct
       &~ match_inst ~id_source ~range:exp.range ~poly_type ~mono_type:exp_type
     | Exp_let_implicit (var_name, exp) ->
       infer_implicit_binding ~env var_name
-      @@ fun () -> infer_exp ~env ~with_poly_params exp exp_type
-    | Exp_implicit -> implicit Type.(var exp_type)
+      @@ fun env -> infer_exp ~env ~with_poly_params exp exp_type
+    | Exp_implicit -> implicit Type.(var exp_type) ~in_:(Env.implicit_scope env)
 
   and infer_exps ~env ~with_poly_params exps k =
     match exps with
@@ -1023,8 +972,7 @@ module Expression = struct
     let_
       (poly_binding
          ([ Flexible, exp_type ]
-          @. []
-          @?-> infer_exp ~env ~with_poly_params exp exp_type
+          @. infer_exp ~env ~with_poly_params exp exp_type
           @=> [ cvar @: Type.var exp_type ]))
       ~in_:(k cvar)
 
@@ -1041,7 +989,7 @@ module Expression = struct
 
   and infer_term ~env ~with_poly_params (term : term) exp_type =
     match term.it with
-    | Term_exp exp -> [], [], infer_exp ~env ~with_poly_params exp exp_type
+    | Term_exp exp -> [], infer_exp ~env ~with_poly_params exp exp_type
     | Term_implicit_fun (pats, exp) ->
       let pat_and_types =
         List.map pats ~f:(fun pat ->
@@ -1059,32 +1007,32 @@ module Expression = struct
           infer_exp ~env ~with_poly_params exp exp_type)
       in
       let implicit_vars = List.map pat_and_types ~f:snd in
-      implicit_vars, List.map implicit_vars ~f:Type.var, cexp
+      implicit_vars, cexp
 
   and infer_value_binding ~(env : Env.t) ~with_poly_params value_binding k =
     let { value_binding_pat = pat; value_binding_term = term } = value_binding.it in
     let exp_type = Type.Var.create ~id_source:(Env.id_source env) () in
-    let implicit_bindings, implicits, cexp =
-      infer_term ~env ~with_poly_params term exp_type
-    in
+    let implicit_vars, cexp = infer_term ~env ~with_poly_params term exp_type in
     let env, bindings, exists_bindings, cpat =
-      infer_pat ~env ~with_poly_params pat exp_type
+      infer_pat
+        ~env
+        ~with_poly_params
+        ~implicits:(List.map implicit_vars ~f:Type.var)
+        pat
+        exp_type
     in
     let cin = k env in
     let_
       (poly_binding
          (((Flexible, exp_type)
-           :: List.map (exists_bindings @ implicit_bindings) ~f:(fun v -> Flexible, v))
-          @. implicits
-          @?-> (cexp &~ cpat)
+           :: List.map (exists_bindings @ implicit_vars) ~f:(fun v -> Flexible, v))
+          @. (cexp &~ cpat)
           @=> bindings))
       ~in_:cin
 
   and infer_implicit_binding ~(env : Env.t) var_name k =
     let binding = find_var_binding ~env var_name in
-    match binding.var with
-    | None -> Omniml_error.(raise @@ unbound_variable ~range:var_name.range var_name.it)
-    | Some var -> let_implicit var ~in_:(k ())
+    k (Env.add_implicit_var env binding.var)
   ;;
 end
 
@@ -1093,9 +1041,9 @@ module Structure = struct
     let { value_type; value_name } = value_desc.it in
     let quantifiers, type_ = Convert.core_scheme ~env ~with_poly_params value_type in
     let quantifiers = List.map ~f:(fun q -> Flexible, q) quantifiers in
-    Env.rename_var env ~var:value_name.it ~in_:(fun env cvar ->
+    Env.rename_var env ~var:value_name.it ~implicit_arity:0 ~in_:(fun env cvar ->
       let c = k env in
-      let_ (poly_binding (quantifiers @. [] @?-> tt @=> [ cvar @: type_ ])) ~in_:c)
+      let_ (poly_binding (quantifiers @. tt @=> [ cvar @: type_ ])) ~in_:c)
   ;;
 
   let infer_type_decl
@@ -1202,6 +1150,6 @@ module Structure = struct
     | { it = Str_implicit var_name; range } :: str ->
       with_range ~range
       @@ Expression.infer_implicit_binding ~env var_name
-      @@ fun () -> infer_str ~env ~with_poly_params str
+      @@ fun env -> infer_str ~env ~with_poly_params str
   ;;
 end

--- a/lib/type_checker/omniml_type_checker.ml
+++ b/lib/type_checker/omniml_type_checker.ml
@@ -20,81 +20,31 @@ let infer_str ?with_stdlib ~with_poly_params str =
   @@ fun env -> Infer.Structure.infer_str ~with_poly_params ~env str
 ;;
 
-module Decreasing_instantiation_check = struct
-  open Omniml_constraint_solver
-  open Termination
-
-  module Ordinal = struct
-    module T = struct
-      type t =
-        { omega_coeff : int
-        ; one_coeff : int
-        }
-      [@@deriving sexp, compare]
+let decreasing_instantiation_spec =
+  let open Omniml_constraint_solver in
+  let open Termination.Budget.Spec in
+  (module struct
+    module Size = struct
+      let rec of_decoded_type (decoded_type : Decoded_type.t) =
+        match decoded_type with
+        | Var _ | Mu _ -> 0
+        | App (decoded_types, _) ->
+          1 + List.sum (module Int) decoded_types ~f:of_decoded_type
+      ;;
     end
 
-    include T
-    include Comparable.Make (T)
+    type t = { sizes : int Constraint.Var.Map.t } [@@deriving sexp_of, compare]
 
-    let of_int n = { one_coeff = n; omega_coeff = 0 }
-    let zero = of_int 0
-    let one = of_int 1
-    let omega = { omega_coeff = 1; one_coeff = 0 }
+    let initial = { sizes = Constraint.Var.Map.empty }
 
-    let ( + ) t1 t2 =
-      { one_coeff = t1.one_coeff + t2.one_coeff
-      ; omega_coeff = t1.omega_coeff + t2.omega_coeff
-      }
+    let consume var expected_type t =
+      let curr_size = Size.of_decoded_type (Lazy.force expected_type) in
+      match Map.find t.sizes var with
+      | Some prev_size when curr_size >= prev_size -> None
+      | None | Some _ -> Some { sizes = Map.set t.sizes ~key:var ~data:curr_size }
     ;;
-  end
-
-  module Size = struct
-    let rec of_decoded_type (decoded_type : Decoded_type.t) =
-      match decoded_type with
-      | Var _ | Mu _ -> Ordinal.omega
-      | App (decoded_types, _) ->
-        Ordinal.(one + List.sum (module Ordinal) decoded_types ~f:of_decoded_type)
-    ;;
-
-    let of_instantiation decoded_types =
-      decoded_types |> List.sum (module Ordinal) ~f:of_decoded_type
-    ;;
-  end
-
-  let reject_if_increasing_instantiation witness =
-    let open Witness in
-    let open Elab.Let_syntax in
-    let instantiation_size_table = Hashtbl.create (module Constraint.Var) in
-    let rec loop witness =
-      match Witness.view witness with
-      | Hole -> return false
-      | Spine s ->
-        let%bind instantiation = Spine.instantiation s in
-        let curr_size = Size.of_instantiation instantiation in
-        let head = Spine.head s in
-        if
-          match Hashtbl.find instantiation_size_table head with
-          | None -> true
-          | Some prev_size -> Ordinal.(curr_size < prev_size)
-        then (
-          Hashtbl.set instantiation_size_table ~key:head ~data:curr_size;
-          loop_args (Spine.args s))
-        else
-          (* [curr_size >= prev_size], therefore reject witness *)
-          return true
-    and loop_args = function
-      | [] -> return false
-      | witness :: witnesses ->
-        let%bind reject = loop witness in
-        if reject then return true else loop_args witnesses
-    in
-    loop witness
-  ;;
-
-  let v : Check.t =
-    { recursive_occurrence_threshold = 256; rejects = reject_if_increasing_instantiation }
-  ;;
-end
+  end : S)
+;;
 
 let check
       ?defaulting
@@ -102,13 +52,16 @@ let check
       ?range
       cst
   =
-  let termination_check =
+  let termination_budget_spec =
+    let open Omniml_constraint_solver.Termination.Budget.Spec in
     match termination_check with
-    | Disabled -> Omniml_constraint_solver.Termination.Check.disabled
-    | Threshold n -> Omniml_constraint_solver.Termination.Check.threshold n
-    | Decreasing_instantiations -> Decreasing_instantiation_check.v
+    | Disabled -> unlimited
+    | Threshold n -> bounded_by n
+    | Decreasing_instantiations -> decreasing_instantiation_spec
   in
-  match Omniml_constraint_solver.(solve ?range ?defaulting ~termination_check cst) with
+  match
+    Omniml_constraint_solver.(solve ?range ?defaulting ~termination_budget_spec cst)
+  with
   | Ok () -> ()
   | Error { range; it } ->
     let get_range range =

--- a/lib/type_checker/omniml_type_checker.ml
+++ b/lib/type_checker/omniml_type_checker.ml
@@ -67,5 +67,8 @@ let check ?defaulting ?range cst =
               type1
               type2)
      | Rigid_variable_escape ->
-       Omniml_error.(raise @@ rigid_variable_escape ~range:(get_range range)))
+       Omniml_error.(raise @@ rigid_variable_escape ~range:(get_range range))
+     | Resolution_termination_check_failed ->
+       Omniml_error.(
+         raise @@ resolution_termination_check_failed ~range:(get_range range)))
 ;;

--- a/lib/type_checker/omniml_type_checker.ml
+++ b/lib/type_checker/omniml_type_checker.ml
@@ -20,8 +20,95 @@ let infer_str ?with_stdlib ~with_poly_params str =
   @@ fun env -> Infer.Structure.infer_str ~with_poly_params ~env str
 ;;
 
-let check ?defaulting ?range cst =
-  match Omniml_constraint_solver.(solve ?range ?defaulting cst) with
+module Decreasing_instantiation_check = struct
+  open Omniml_constraint_solver
+  open Termination
+
+  module Ordinal = struct
+    module T = struct
+      type t =
+        { omega_coeff : int
+        ; one_coeff : int
+        }
+      [@@deriving sexp, compare]
+    end
+
+    include T
+    include Comparable.Make (T)
+
+    let of_int n = { one_coeff = n; omega_coeff = 0 }
+    let zero = of_int 0
+    let one = of_int 1
+    let omega = { omega_coeff = 1; one_coeff = 0 }
+
+    let ( + ) t1 t2 =
+      { one_coeff = t1.one_coeff + t2.one_coeff
+      ; omega_coeff = t1.omega_coeff + t2.omega_coeff
+      }
+    ;;
+  end
+
+  module Size = struct
+    let rec of_decoded_type (decoded_type : Decoded_type.t) =
+      match decoded_type with
+      | Var _ | Mu _ -> Ordinal.omega
+      | App (decoded_types, _) ->
+        Ordinal.(one + List.sum (module Ordinal) decoded_types ~f:of_decoded_type)
+    ;;
+
+    let of_instantiation decoded_types =
+      decoded_types |> List.sum (module Ordinal) ~f:of_decoded_type
+    ;;
+  end
+
+  let reject_if_increasing_instantiation witness =
+    let open Witness in
+    let open Elab.Let_syntax in
+    let instantiation_size_table = Hashtbl.create (module Constraint.Var) in
+    let rec loop witness =
+      match Witness.view witness with
+      | Hole -> return false
+      | Spine s ->
+        let%bind instantiation = Spine.instantiation s in
+        let curr_size = Size.of_instantiation instantiation in
+        let head = Spine.head s in
+        if
+          match Hashtbl.find instantiation_size_table head with
+          | None -> true
+          | Some prev_size -> Ordinal.(curr_size < prev_size)
+        then (
+          Hashtbl.set instantiation_size_table ~key:head ~data:curr_size;
+          loop_args (Spine.args s))
+        else
+          (* [curr_size >= prev_size], therefore reject witness *)
+          return true
+    and loop_args = function
+      | [] -> return false
+      | witness :: witnesses ->
+        let%bind reject = loop witness in
+        if reject then return true else loop_args witnesses
+    in
+    loop witness
+  ;;
+
+  let v : Check.t =
+    { recursive_occurrence_threshold = 256; rejects = reject_if_increasing_instantiation }
+  ;;
+end
+
+let check
+      ?defaulting
+      ?(termination_check = Omniml_options.Termination_check.default)
+      ?range
+      cst
+  =
+  let termination_check =
+    match termination_check with
+    | Disabled -> Omniml_constraint_solver.Termination.Check.disabled
+    | Threshold n -> Omniml_constraint_solver.Termination.Check.threshold n
+    | Decreasing_instantiations -> Decreasing_instantiation_check.v
+  in
+  match Omniml_constraint_solver.(solve ?range ?defaulting ~termination_check cst) with
   | Ok () -> ()
   | Error { range; it } ->
     let get_range range =

--- a/lib/type_checker/omniml_type_checker.mli
+++ b/lib/type_checker/omniml_type_checker.mli
@@ -19,6 +19,7 @@ val infer_str
     @raises Omniml_error.T if the constraint is unsatisfiable *)
 val check
   :  ?defaulting:Omniml_options.Defaulting.t
+  -> ?termination_check:Omniml_options.Termination_check.t
   -> ?range:Range.t
   -> Constraint.t
   -> unit

--- a/lib/type_checker/predef.ml
+++ b/lib/type_checker/predef.ml
@@ -43,20 +43,20 @@ module Env = struct
   let t = [ "int", 0, int_ident; "bool", 0, bool_ident; "unit", 0, unit_ident ]
 
   let v ~with_poly_params =
-    [ "( || )", bool_bop ~with_poly_params
-    ; "( && )", bool_bop ~with_poly_params
-    ; "not", bool_uop ~with_poly_params
-    ; "( = )", int_comparator ~with_poly_params
-    ; "( <> )", int_comparator ~with_poly_params
-    ; "( < )", int_comparator ~with_poly_params
-    ; "( > )", int_comparator ~with_poly_params
-    ; "( <= )", int_comparator ~with_poly_params
-    ; "( >= )", int_comparator ~with_poly_params
-    ; "( + )", int_bop ~with_poly_params
-    ; "( - )", int_bop ~with_poly_params
-    ; "( * )", int_bop ~with_poly_params
-    ; "( / )", int_bop ~with_poly_params
-    ; "unary( - )", int_uop ~with_poly_params
+    [ "( || )", 0, bool_bop ~with_poly_params
+    ; "( && )", 0, bool_bop ~with_poly_params
+    ; "not", 0, bool_uop ~with_poly_params
+    ; "( = )", 0, int_comparator ~with_poly_params
+    ; "( <> )", 0, int_comparator ~with_poly_params
+    ; "( < )", 0, int_comparator ~with_poly_params
+    ; "( > )", 0, int_comparator ~with_poly_params
+    ; "( <= )", 0, int_comparator ~with_poly_params
+    ; "( >= )", 0, int_comparator ~with_poly_params
+    ; "( + )", 0, int_bop ~with_poly_params
+    ; "( - )", 0, int_bop ~with_poly_params
+    ; "( * )", 0, int_bop ~with_poly_params
+    ; "( / )", 0, int_bop ~with_poly_params
+    ; "unary( - )", 0, int_uop ~with_poly_params
     ]
   ;;
 
@@ -72,9 +72,15 @@ module Env = struct
   let wrap ~with_poly_params k =
     let env = init () in
     let env, bindings =
-      List.fold_map (v ~with_poly_params) ~init:env ~f:(fun env (var_str, type_) ->
-        Env.rename_var env ~var:(Var_name.create var_str) ~in_:(fun env cvar ->
-          env, (cvar, type_)))
+      List.fold_map
+        (v ~with_poly_params)
+        ~init:env
+        ~f:(fun env (var_str, implicit_arity, type_) ->
+          Env.rename_var
+            env
+            ~var:(Var_name.create var_str)
+            ~implicit_arity
+            ~in_:(fun env cvar -> env, (cvar, type_)))
     in
     let c = k env in
     let_ (mono_binding (List.map bindings ~f:(fun (var, type_) -> var @: type_))) ~in_:c


### PR DESCRIPTION
Adds support for a simple implicit calculus:

```ocaml
let implicit x in e
```
adds `x` to the implicit environment in `e`

with a second-class implicit abstraction:
```ocaml
let x = fun? p1 ... pn -> e
```
that binds implicit values matched by patterns `p1, ..., pn`. 